### PR TITLE
feat: 공통 통신 로직 작성

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import '@/app/globals.css';
+import QueryProvider from '@/shared/provider/QueryProvider';
 
 const pretendard = localFont({
   src: '../shared/assets/fonts/PretendardVariable.woff2',
@@ -21,7 +22,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={`${pretendard.variable} ${pretendard.className}`}>
-      <body>{children}</body>
+      <QueryProvider>
+        <body>{children}</body>
+      </QueryProvider>
     </html>
   );
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export async function proxy(request: NextRequest) {
+  const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
+
+  // 1. 토큰 갱신 필요 여부 판별 (만료되었고, 리프레시 토큰은 존재하는 경우)
+  const isTokenExpired = !accessToken;
+
+  if (isTokenExpired && refreshToken) {
+    try {
+      // 2. 토큰 재발급 API 호출
+      const refreshApiUrl = `${BASE_API_URL}/oauth/refresh`;
+      const refreshRes = await fetch(refreshApiUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `refreshToken=${refreshToken}`,
+        },
+      });
+
+      if (refreshRes.ok) {
+        const result = await refreshRes.json();
+
+        if (result.success && result.data) {
+          const newAccessToken = result.data.accessToken;
+          const newRefreshToken = result.data.refreshToken;
+
+          // 3. 서버 컴포넌트(Server Action)가 참조할 내부 Request 헤더 조작
+          request.cookies.set('accessToken', newAccessToken);
+          request.cookies.set('refreshToken', newRefreshToken);
+
+          const requestHeaders = new Headers(request.headers);
+          requestHeaders.set('Cookie', request.cookies.toString());
+
+          // 4. 조작된 헤더를 포함하여 요청 통과
+          const response = NextResponse.next({
+            request: { headers: requestHeaders },
+          });
+
+          // 5. 브라우저에 저장될 Response 쿠키 세팅
+          response.cookies.set('accessToken', newAccessToken, {
+            maxAge: 60 * 60,
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'none',
+            path: '/',
+          });
+          response.cookies.set('refreshToken', newRefreshToken, {
+            maxAge: 60 * 60 * 24 * 14,
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'none',
+            path: '/',
+          });
+
+          return response;
+        }
+      }
+    } catch (error) {
+      // 갱신 실패 시 조작 없이 통과 (이후 httpClient가 401/SESSION_EXPIRED 반환)
+    }
+  }
+
+  return NextResponse.next();
+}
+
+// 정적 자원(이미지, 폰트 등) 요청에는 실행되지 않도록 최적화
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -1,0 +1,103 @@
+import { cookies } from 'next/headers';
+import { ApiResponse, ApiErrorResponse, ApiSuccessResponse } from '@/shared/types/api';
+
+const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+/**
+ * 내부 헬퍼 함수: 예상치 못한 시스템/네트워크 에러를 표준 실패 포맷으로 규격화
+ */
+function createErrorResponse(code: string, message: string): ApiErrorResponse {
+  return {
+    success: false,
+    code,
+    message,
+    data: null,
+    errors: [],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * [Token O] 인증이 필요한 공통 Fetch
+ * - proxy.ts에서 이미 갱신 처리를 완료했다고 가정
+ * - 여기서 401이 발생하면 토큰이 완전히 만료된 상태이므로 세션 만료 에러를 반환
+ */
+export async function privateFetch<T>(
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  const cookieStore = await cookies();
+  const currentToken = cookieStore.get('accessToken')?.value;
+
+  if (!currentToken) {
+    return createErrorResponse('SESSION_EXPIRED', '접근 권한이 없습니다. 다시 로그인해 주세요.');
+  }
+
+  try {
+    const response = await fetch(`${BASE_API_URL}${endpoint}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${currentToken}`,
+        ...options.headers,
+      },
+    });
+
+    const result = await response.json();
+
+    if (!response.ok || !result.success) {
+      if (response.status === 401) {
+        return createErrorResponse(
+          'SESSION_EXPIRED',
+          '세션이 만료되었습니다. 다시 로그인해 주세요.',
+        );
+      }
+
+      return {
+        success: false,
+        code: result.code || 'HTTP_ERROR',
+        message: result.message || '요청 처리에 실패했습니다.',
+        data: null,
+        errors: result.errors || [],
+      };
+    }
+
+    return result as ApiSuccessResponse<T>;
+  } catch (error) {
+    return createErrorResponse('NETWORK_ERROR', '서버와의 통신에 실패했습니다.');
+  }
+}
+
+/**
+ * [Token X] 인증이 필요 없는 공통 Fetch
+ */
+export async function publicFetch<T>(
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  try {
+    const response = await fetch(`${BASE_API_URL}${endpoint}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    const result = await response.json();
+
+    if (!response.ok || !result.success) {
+      return {
+        success: false,
+        code: result.code || 'HTTP_ERROR',
+        message: result.message || '요청 처리에 실패했습니다.',
+        data: null,
+        errors: result.errors || [],
+      };
+    }
+
+    return result as ApiSuccessResponse<T>;
+  } catch (error) {
+    return createErrorResponse('NETWORK_ERROR', '서버와의 통신에 실패했습니다.');
+  }
+}

--- a/src/shared/provider/QueryProvider.tsx
+++ b/src/shared/provider/QueryProvider.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+            // SSR로 받아온 데이터가 마운트 즉시 재요청되는 것을 방지 (예: 1분 유지)
+            staleTime: 60 * 1000,
+            refetchOnWindowFocus: false, // 필요에 따라 창 포커스 시 재요청 방지
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,0 +1,27 @@
+// 성공 응답 타입
+export interface ApiSuccessResponse<T> {
+  success: true;
+  code: string;
+  message: string;
+  data: T;
+  timestamp?: string;
+}
+
+// 실패 응답의 상세 에러 배열 타입
+export interface ApiErrorDetail {
+  field: string;
+  reason: string;
+}
+
+// 실패 응답 타입
+export interface ApiErrorResponse {
+  success: false;
+  code: string;
+  message: string;
+  data: null;
+  errors?: ApiErrorDetail[];
+  timestamp?: string;
+}
+
+// 공통 응답 유니온 타입
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;


### PR DESCRIPTION
## 작업 내용

- 공통 통신 로직 작성
  - `proxy.ts`: 토큰 만료 체크 후, 토큰 재발급 api 호출 담당
  - `shared/types/api.ts` : 공통 api 응답 타입 정의
  - `shared/api/httpClient.ts`: fetch wrapper(`publicFetch`, `privateFetch`) 정의
  - `shared/provider/QueryProvider.tsx`: 클라이언트 단 전역 QueryClient 인스턴스 관리
    -> 최상단 layout에서 감싸도록 반영


## 리뷰 필요

1. 통신 로직 흐름 확인 필요.

close #23 
