### PR TITLE
feat: prefetch/hydration 구조, 액션(생성/수정/발행/삭제) 연동 정리

### DIFF
--- a/src/app/(main)/industry/[industryId]/analysis/[analysisId]/page.tsx
+++ b/src/app/(main)/industry/[industryId]/analysis/[analysisId]/page.tsx
@@ -1,11 +1,9 @@
-import TopBar from '@/shared/components/layout/TopBar';
-import ContentHeader from '@/shared/components/layout/ContentHeader';
-import { mockIndustries, mockIndustriesAnalysis } from '@/mocks';
-import { Button } from '@/shared/components/ui/button';
-import { Card, CardContent } from '@/shared/components/ui/card';
-import { formatDate } from '@/shared/lib/formatDate';
-import IndustryAnalysisCard from '@/features/industry/components/section/IndustryAnalysisCard';
-import IndustryStatusCard from '@/features/industry/components/section/IndutryStatusCard';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import {
+  industryAnalysisQueryOptions,
+  industryCategoryListQueryOptions,
+} from '@/features/industry/queries';
+import IndustryAnalysisSection from '@/features/industry/components/section/IndustryAnalysisSection';
 
 export default async function AnalysisDetailPage({
   params,
@@ -13,48 +11,17 @@ export default async function AnalysisDetailPage({
   params: Promise<{ industryId: string; analysisId: string }>;
 }) {
   const { industryId, analysisId } = await params;
-  const industry = mockIndustries.find((item) => item.industryId === Number(industryId));
-  const label = industry?.name ?? '산업군';
-  // TODO : 산업 분석 단건 조회 API 호출 위치 (/api/v1/admin/industries/reports/{id})
-  const analysis = mockIndustriesAnalysis.find((v) => v.analysisId === Number(analysisId));
-  const yearLabel = analysis?.analysisYear ?? analysisId;
+  const queryClient = new QueryClient();
+  await Promise.all([
+    queryClient.prefetchQuery(industryCategoryListQueryOptions),
+    queryClient.prefetchQuery(industryAnalysisQueryOptions(Number(analysisId))),
+  ]);
 
   return (
     <>
-      <TopBar title="산업군 관리" breadcrumb={`산업군 관리 > ${label} > ${yearLabel}년 분석`} />
-
-      <main className="flex flex-1 flex-col gap-5 overflow-auto bg-ds-grey-100 p-6">
-        <ContentHeader
-          title={`${label} - ${yearLabel} 분석`}
-          titleClassName="text-[30px]"
-          description={`수정일: ${formatDate(analysis?.updatedAt)}`}
-          descriptionClassName="pl-7"
-          backHref="/industry"
-          actionsAlign="start"
-          actions={
-            <>
-              {/* TODO: 산업 분석 수정 API 조회 위치 (/api/v1/admin/industries/reports/{id}) */}
-              <Button variant="outline" className="text-ds-badge-red-text">
-                삭제
-              </Button>
-              <Button className="bg-ds-grey-900 text-white hover:bg-ds-grey-800">발행</Button>
-            </>
-          }
-        />
-
-        {analysis ? (
-          <div className="flex items-start gap-4">
-            <IndustryAnalysisCard analysis={analysis} />
-            <IndustryStatusCard status={analysis.analysisStatus} analyzedYear={analysis.analysisYear} />
-          </div>
-        ) : (
-          <Card className="border-ds-grey-200 bg-white py-10">
-            <CardContent className="flex items-center justify-center">
-              <p className="text-sm text-ds-grey-500">버전 정보를 찾을 수 없습니다.</p>
-            </CardContent>
-          </Card>
-        )}
-      </main>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <IndustryAnalysisSection industryId={Number(industryId)} analysisId={Number(analysisId)} />
+      </HydrationBoundary>
     </>
   );
 }

--- a/src/app/(main)/industry/[industryId]/page.tsx
+++ b/src/app/(main)/industry/[industryId]/page.tsx
@@ -1,10 +1,9 @@
-import TopBar from '@/shared/components/layout/TopBar';
-import ContentHeader from '@/shared/components/layout/ContentHeader';
-import { mockIndustries, mockIndustriesAnalysis } from '@/mocks';
-import { Button } from '@/shared/components/ui/button';
-import IndustryBasicInfoCard from '@/features/industry/components/ui/IndustryBasicInfoCard';
-import IndustryAnalysisTable from '@/features/industry/components/section/IndustryAnalysisTable';
-import IndustryInfoSideCard from '@/features/industry/components/ui/IndustryInfoSideCard';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import {
+  industryAnalysisListQueryOptions,
+  industryCategoryListQueryOptions,
+} from '@/features/industry/queries';
+import IndustryDetailSection from '@/features/industry/components/section/IndustryDetailSection';
 
 export default async function IndustryDetailPage({
   params,
@@ -12,39 +11,17 @@ export default async function IndustryDetailPage({
   params: Promise<{ industryId: string }>;
 }) {
   const { industryId } = await params;
-  const industry = mockIndustries.find((item) => item.industryId === Number(industryId));
-  const label = industry?.name ?? '산업군';
-  // TODO: 산업 분석 목록 조회 API 호출 위치 (/api/v1/admin/industries/{id}/reports)
-  // TODO: 산업 분석 단일 리포트 수정/상세 조회 API (별도 수정 화면 진입 시 사용) (/api/v1/admin/industries/reports/{id})
-  const analysis = mockIndustriesAnalysis.filter((v) => v.industryId === Number(industryId));
-  const publishedAnalysis = analysis.find((v) => v.analysisStatus === 'PUBLISHED');
+  const queryClient = new QueryClient();
+  await Promise.all([
+    queryClient.prefetchQuery(industryCategoryListQueryOptions),
+    queryClient.prefetchQuery(industryAnalysisListQueryOptions(Number(industryId))),
+  ]);
 
   return (
     <>
-      <TopBar title="산업군 관리" breadcrumb={`산업군 관리 > ${label}`} />
-
-      <main className="flex-1 overflow-auto bg-ds-grey-100 p-6 flex flex-col gap-5">
-        <ContentHeader
-          title={label}
-          backHref="/industry"
-          actions={
-            <Button variant="outline" className="text-ds-badge-red-text">
-              산업 삭제
-            </Button>
-          }
-        />
-
-        <div className="flex gap-5 items-start">
-          <div className="flex-1 flex flex-col gap-4">
-            <IndustryBasicInfoCard label={label} />
-            <IndustryAnalysisTable industryId={industryId} analysis={analysis} />
-          </div>
-          <IndustryInfoSideCard
-            analysisCount={analysis.length}
-            publishedAnalysis={publishedAnalysis}
-          />
-        </div>
-      </main>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <IndustryDetailSection industryId={Number(industryId)} />
+      </HydrationBoundary>
     </>
   );
 }

--- a/src/app/(main)/industry/page.tsx
+++ b/src/app/(main)/industry/page.tsx
@@ -1,10 +1,14 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import TopBar from '@/shared/components/layout/TopBar';
 import ContentHeader from '@/shared/components/layout/ContentHeader';
-import { mockIndustries } from '@/mocks';
 import IndustryAddButton from '@/features/industry/components/ui/IndustryAddButton';
 import IndustryList from '@/features/industry/components/section/IndustryList';
+import { industryCategoryListQueryOptions } from '@/features/industry/queries';
 
-export default function IndustryPage() {
+export default async function IndustryPage() {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery(industryCategoryListQueryOptions);
+
   return (
     <>
       <TopBar title="산업군 관리" breadcrumb="산업 카테고리를 관리합니다" />
@@ -12,10 +16,11 @@ export default function IndustryPage() {
       <main className="flex-1 overflow-auto bg-ds-grey-100 p-8 flex flex-col gap-6">
         <ContentHeader
           title="산업군 목록"
-          description={`총 ${mockIndustries.length}개 카테고리가 등록되어 있습니다`}
           actions={<IndustryAddButton />}
         />
-        <IndustryList />
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <IndustryList />
+        </HydrationBoundary>
       </main>
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import '@/app/globals.css';
 import QueryProvider from '@/shared/provider/QueryProvider';
+import { Toaster } from '@/shared/components/ui/sonner';
 
 const pretendard = localFont({
   src: '../shared/assets/fonts/PretendardVariable.woff2',
@@ -23,7 +24,10 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable} ${pretendard.className}`}>
       <QueryProvider>
-        <body>{children}</body>
+        <body>
+          {children}
+          <Toaster richColors position="top-right" />
+        </body>
       </QueryProvider>
     </html>
   );

--- a/src/features/industry/actions.ts
+++ b/src/features/industry/actions.ts
@@ -26,7 +26,10 @@ export async function createIndustryCategory(data: CreateIndustryCategoryRequest
 }
 
 // 산업 카테고리 수정 — PATCH /api/v1/admin/industries/{id}
-export async function updateIndustryCategory(industryId: number, data: UpdateIndustryCategoryRequest) {
+export async function updateIndustryCategory(
+  industryId: number,
+  data: UpdateIndustryCategoryRequest,
+) {
   return privateFetch<IndustryCategory>(`/api/v1/admin/industries/${industryId}`, {
     method: 'PATCH',
     body: JSON.stringify(data),
@@ -48,7 +51,10 @@ export async function getIndustryAnalysis(analysisId: number) {
 }
 
 // 산업 분석 생성 — POST /api/v1/admin/industries/{id}/reports
-export async function createIndustryAnalysis(industryId: number, data: CreateIndustryAnalysisRequest) {
+export async function createIndustryAnalysis(
+  industryId: number,
+  data: CreateIndustryAnalysisRequest,
+) {
   return privateFetch<IndustryAnalysis>(`/api/v1/admin/industries/${industryId}/reports`, {
     method: 'POST',
     body: JSON.stringify(data),

--- a/src/features/industry/components/section/AnalysisDetailActions.tsx
+++ b/src/features/industry/components/section/AnalysisDetailActions.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/shared/components/ui/button';
+import { usePublishIndustryAnalysis, useDeleteIndustryAnalysis } from '@/features/industry/queries';
+
+interface AnalysisDetailActionsProps {
+  industryId: number;
+  analysisId: number;
+  isPublished: boolean;
+}
+
+export default function AnalysisDetailActions({
+  industryId,
+  analysisId,
+  isPublished,
+}: AnalysisDetailActionsProps) {
+  const router = useRouter();
+  const { mutate: publish, isPending: isPublishing } = usePublishIndustryAnalysis(industryId);
+  const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(industryId);
+
+  const handlePublish = () => {
+    publish(analysisId, { onSuccess: () => router.refresh() });
+  };
+
+  const handleDelete = () => {
+    deleteAnalysis(analysisId, { onSuccess: () => router.push(`/industry/${industryId}`) });
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        className="text-ds-badge-red-text"
+        disabled={isDeleting}
+        onClick={handleDelete}
+      >
+        삭제
+      </Button>
+      <Button
+        className="bg-ds-grey-900 text-white hover:bg-ds-grey-800"
+        disabled={isPublished || isPublishing}
+        onClick={handlePublish}
+      >
+        발행
+      </Button>
+    </>
+  );
+}

--- a/src/features/industry/components/section/AnalysisDetailActions.tsx
+++ b/src/features/industry/components/section/AnalysisDetailActions.tsx
@@ -20,7 +20,7 @@ export default function AnalysisDetailActions({
   const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(industryId);
 
   const handlePublish = () => {
-    publish(analysisId);
+    publish(analysisId, { onSuccess: () => router.refresh() });
   };
 
   const handleDelete = () => {
@@ -32,7 +32,7 @@ export default function AnalysisDetailActions({
       <Button
         variant="outline"
         className="text-ds-badge-red-text"
-        disabled={isDeleting}
+        disabled={isDeleting || isPublishing}
         onClick={handleDelete}
       >
         삭제

--- a/src/features/industry/components/section/AnalysisDetailActions.tsx
+++ b/src/features/industry/components/section/AnalysisDetailActions.tsx
@@ -3,6 +3,9 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '@/shared/components/ui/button';
 import { usePublishIndustryAnalysis, useDeleteIndustryAnalysis } from '@/features/industry/queries';
+import { on } from 'events';
+import { toast } from 'sonner';
+import { ApiErrorResponse } from '@/shared/types/api';
 
 interface AnalysisDetailActionsProps {
   industryId: number;
@@ -20,11 +23,25 @@ export default function AnalysisDetailActions({
   const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(industryId);
 
   const handlePublish = () => {
-    publish(analysisId, { onSuccess: () => router.refresh() });
+    publish(analysisId, {
+      onSuccess: () => {
+        toast.success('산업 분석이 발행되었습니다.');
+      },
+      onError: (error: ApiErrorResponse) => {
+        toast.error(error.message || '산업 분석 발행에 실패했습니다.');
+      },
+    });
   };
 
   const handleDelete = () => {
-    deleteAnalysis(analysisId, { onSuccess: () => router.push(`/industry/${industryId}`) });
+    deleteAnalysis(analysisId, {
+      onSuccess: () => {
+        toast.success('산업 분석이 삭제되었습니다.');
+      },
+      onError: (error: ApiErrorResponse) => {
+        toast.error(error.message || '산업 분석 삭제에 실패했습니다.');
+      },
+    });
   };
 
   return (

--- a/src/features/industry/components/section/AnalysisDetailActions.tsx
+++ b/src/features/industry/components/section/AnalysisDetailActions.tsx
@@ -20,7 +20,7 @@ export default function AnalysisDetailActions({
   const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(industryId);
 
   const handlePublish = () => {
-    publish(analysisId, { onSuccess: () => router.refresh() });
+    publish(analysisId);
   };
 
   const handleDelete = () => {

--- a/src/features/industry/components/section/AnalysisDetailActions.tsx
+++ b/src/features/industry/components/section/AnalysisDetailActions.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '@/shared/components/ui/button';
 import { usePublishIndustryAnalysis, useDeleteIndustryAnalysis } from '@/features/industry/queries';
-import { on } from 'events';
 import { toast } from 'sonner';
 import { ApiErrorResponse } from '@/shared/types/api';
 

--- a/src/features/industry/components/section/IndustryAnalysisNewForm.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisNewForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardTitle } from '@/shared/components/ui/card';
 import { Input } from '@/shared/components/ui/input';
@@ -10,6 +10,9 @@ import ContentHeader from '@/shared/components/layout/ContentHeader';
 import CardActionForm from '@/shared/components/ui/CardActionForm';
 import TagField from '@/features/industry/components/ui/TagField';
 import { useTagField } from '@/features/industry/hooks/useTagField';
+import { useCreateIndustryAnalysis } from '@/features/industry/queries';
+import { toast } from 'sonner';
+import { ApiErrorResponse } from '@/shared/types/api';
 
 interface IndustryAnalysisNewFormProps {
   industryId: string;
@@ -17,7 +20,7 @@ interface IndustryAnalysisNewFormProps {
 
 export default function IndustryAnalysisNewForm({ industryId }: IndustryAnalysisNewFormProps) {
   const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+  const { mutate: createAnalysis, isPending } = useCreateIndustryAnalysis(Number(industryId));
 
   const [analyzedYear, setAnalyzedYear] = useState('');
   const [marketSize, setMarketSize] = useState('');
@@ -46,17 +49,40 @@ export default function IndustryAnalysisNewForm({ industryId }: IndustryAnalysis
     (investment.tags.length > 0 || investment.inputValue.trim().length > 0);
 
   const handleSubmit = () => {
-    if (keyword.inputValue.trim()) keyword.onAdd();
-    if (trend.inputValue.trim()) trend.onAdd();
-    if (risk.inputValue.trim()) risk.onAdd();
-    if (hiring.inputValue.trim()) hiring.onAdd();
-    if (investment.inputValue.trim()) investment.onAdd();
+    const finalKeyword = keyword.inputValue.trim()
+      ? [...keyword.tags, keyword.inputValue.trim()]
+      : keyword.tags;
+    const finalTrend = trend.inputValue.trim()
+      ? [...trend.tags, trend.inputValue.trim()]
+      : trend.tags;
+    const finalRegulation = risk.inputValue.trim()
+      ? [...risk.tags, risk.inputValue.trim()]
+      : risk.tags;
+    const finalHiring = hiring.inputValue.trim()
+      ? [...hiring.tags, hiring.inputValue.trim()]
+      : hiring.tags;
+    const finalInvestment = investment.inputValue.trim()
+      ? [...investment.tags, investment.inputValue.trim()]
+      : investment.tags;
 
-    startTransition(async () => {
-      // TODO: 산업 분석 생성 API 호출 위치(/api/v1/admin/industries/{id}/reports)
-      // TODO: server action 연결
-      router.push(`/industry/${industryId}`);
-    });
+    createAnalysis(
+      {
+        analysisYear: Number(analyzedYear),
+        keyword: finalKeyword,
+        marketSize: marketSize.trim(),
+        trend: finalTrend,
+        regulation: finalRegulation,
+        competition: rival.trim(),
+        hiring: finalHiring,
+        investment: finalInvestment,
+      },
+      {
+        onSuccess: () => router.push(`/industry/${industryId}`),
+        onError: (error: ApiErrorResponse) => {
+          toast.error('산업 분석 생성 실패:' + error.message);
+        },
+      },
+    );
   };
 
   const handleAnalyzedYearChange = (value: string) => {
@@ -161,7 +187,7 @@ export default function IndustryAnalysisNewForm({ industryId }: IndustryAnalysis
             primaryLabel={isPending ? '저장 중...' : '저장'}
             primaryButtonClassName="bg-ds-grey-900 text-white hover:bg-ds-grey-800"
             primaryEnabled={isPrimaryEnabled}
-            onPrimaryClick={handleSubmit} //TODO: 산업 분석 버전 생성 API 연결
+            onPrimaryClick={handleSubmit}
             secondaryLabel="취소"
             onSecondaryClick={() => router.push(`/industry/${industryId}`)}
             secondaryUseBack

--- a/src/features/industry/components/section/IndustryAnalysisNewForm.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisNewForm.tsx
@@ -77,9 +77,12 @@ export default function IndustryAnalysisNewForm({ industryId }: IndustryAnalysis
         investment: finalInvestment,
       },
       {
-        onSuccess: () => router.push(`/industry/${industryId}`),
+        onSuccess: () => {
+          router.push(`/industry/${industryId}`);
+          toast.success('산업 분석이 생성되었습니다!');
+        },
         onError: (error: ApiErrorResponse) => {
-          toast.error('산업 분석 생성 실패:' + error.message);
+          toast.error(error.message || '산업 분석 생성 실패');
         },
       },
     );

--- a/src/features/industry/components/section/IndustryAnalysisSection.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisSection.tsx
@@ -18,7 +18,7 @@ export default function IndustryAnalysisSection({
   analysisId,
 }: IndustryAnalysisSectionProps) {
   const { data: categoryList } = useIndustryCategoryList();
-  const { data: analysis } = useIndustryAnalysis(industryId);
+  const { data: analysis } = useIndustryAnalysis(analysisId);
   const label =
     categoryList?.find((category) => category.industryId === industryId)?.industryName || '산업군';
   const yearLabel = analysis?.analysisYear;

--- a/src/features/industry/components/section/IndustryAnalysisSection.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisSection.tsx
@@ -21,7 +21,7 @@ export default function IndustryAnalysisSection({
   const { data: analysis } = useIndustryAnalysis(analysisId);
   const label =
     categoryList?.find((category) => category.industryId === industryId)?.industryName || '산업군';
-  const yearLabel = analysis?.analysisYear;
+  const yearLabel = analysis?.analysisYear ?? '-';
 
   const isValidIndustryId = Number.isFinite(industryId) && industryId > 0;
   const isValidAnalysisId = Number.isFinite(analysisId) && analysisId > 0;

--- a/src/features/industry/components/section/IndustryAnalysisSection.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisSection.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import ContentHeader from '@/shared/components/layout/ContentHeader';
+import TopBar from '@/shared/components/layout/TopBar';
+import AnalysisDetailActions from './AnalysisDetailActions';
+import IndustryAnalysisCard from './IndustryAnalysisCard';
+import IndustryStatusCard from './IndutryStatusCard';
+import { Card, CardContent } from '@/shared/components/ui/card';
+import { useIndustryAnalysis, useIndustryCategoryList } from '../../queries';
+import { formatDate } from '@/shared/lib/formatDate';
+
+interface IndustryAnalysisSectionProps {
+  industryId: number;
+  analysisId: number;
+}
+export default function IndustryAnalysisSection({
+  industryId,
+  analysisId,
+}: IndustryAnalysisSectionProps) {
+  const { data: categoryList } = useIndustryCategoryList();
+  const { data: analysis } = useIndustryAnalysis(industryId);
+  const label =
+    categoryList?.find((category) => category.industryId === industryId)?.industryName || '산업군';
+  const yearLabel = analysis?.analysisYear;
+
+  const isValidIndustryId = Number.isFinite(industryId) && industryId > 0;
+  const isValidAnalysisId = Number.isFinite(analysisId) && analysisId > 0;
+
+  return (
+    <>
+      <TopBar title="산업군 관리" breadcrumb={`산업군 관리 > ${label} > ${yearLabel}년 분석`} />
+
+      <main className="flex flex-1 flex-col gap-5 overflow-auto bg-ds-grey-100 p-6">
+        <ContentHeader
+          title={`${label} - ${yearLabel} 분석`}
+          titleClassName="text-[30px]"
+          description={`수정일: ${formatDate(analysis?.updatedAt)}`}
+          descriptionClassName="pl-7"
+          backHref={`/industry/${industryId}`}
+          actionsAlign="start"
+          actions={
+            analysis && isValidIndustryId && isValidAnalysisId ? (
+              <AnalysisDetailActions
+                industryId={industryId}
+                analysisId={analysisId}
+                isPublished={analysis?.analysisStatus === 'PUBLISHED'}
+              />
+            ) : null
+          }
+        />
+
+        {analysis ? (
+          <div className="flex items-start gap-4">
+            <IndustryAnalysisCard analysis={analysis} />
+            <IndustryStatusCard
+              status={analysis.analysisStatus}
+              analyzedYear={analysis.analysisYear}
+            />
+          </div>
+        ) : (
+          <Card className="border-ds-grey-200 bg-white py-10">
+            <CardContent className="flex items-center justify-center">
+              <p className="text-sm text-ds-grey-500">분석 정보를 찾을 수 없습니다.</p>
+            </CardContent>
+          </Card>
+        )}
+      </main>
+    </>
+  );
+}

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
 import { ANALYSIS_STATUS_LABELS } from '@/features/industry/constants';
@@ -20,7 +19,6 @@ export default function IndustryAnalysisTable({
   industryId,
   analysis,
 }: IndustryAnalysisTableProps) {
-  const router = useRouter();
   const { mutate: publish, isPending: isPublishing } = usePublishIndustryAnalysis(
     Number(industryId),
   );
@@ -30,7 +28,6 @@ export default function IndustryAnalysisTable({
 
   const handlePublish = (analysisId: number) => {
     publish(analysisId, {
-      onSuccess: () => router.refresh(),
       onError: (error: ApiErrorResponse) => {
         toast.error(error.message || '산업 분석 발행에 실패했습니다.');
       },
@@ -39,7 +36,6 @@ export default function IndustryAnalysisTable({
 
   const handleDelete = (analysisId: number) => {
     deleteAnalysis(analysisId, {
-      onSuccess: () => router.refresh(),
       onError: (error: ApiErrorResponse) => {
         toast.error(error.message || '산업 분석 삭제에 실패했습니다.');
       },

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -19,12 +19,8 @@ export default function IndustryAnalysisTable({
   industryId,
   analysis,
 }: IndustryAnalysisTableProps) {
-  const { mutate: publish, isPending: isPublishing } = usePublishIndustryAnalysis(
-    Number(industryId),
-  );
-  const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(
-    Number(industryId),
-  );
+  const { mutate: publish, isPending: isPublishing } = usePublishIndustryAnalysis(industryId);
+  const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(industryId);
 
   const handlePublish = (analysisId: number) => {
     publish(analysisId, {

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -24,6 +24,9 @@ export default function IndustryAnalysisTable({
 
   const handlePublish = (analysisId: number) => {
     publish(analysisId, {
+      onSuccess: () => {
+        toast.success('산업 분석이 발행되었습니다.');
+      },
       onError: (error: ApiErrorResponse) => {
         toast.error(error.message || '산업 분석 발행에 실패했습니다.');
       },
@@ -32,6 +35,9 @@ export default function IndustryAnalysisTable({
 
   const handleDelete = (analysisId: number) => {
     deleteAnalysis(analysisId, {
+      onSuccess: () => {
+        toast.success('산업 분석이 삭제되었습니다.');
+      },
       onError: (error: ApiErrorResponse) => {
         toast.error(error.message || '산업 분석 삭제에 실패했습니다.');
       },

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -1,20 +1,53 @@
+'use client';
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
 import { ANALYSIS_STATUS_LABELS } from '@/features/industry/constants';
 import { formatDate } from '@/shared/lib/formatDate';
-
-import type { IndustryAnalysis } from '@/features/industry/types';
+import { usePublishIndustryAnalysis, useDeleteIndustryAnalysis } from '@/features/industry/queries';
+import type { IndustryAnalysisListItem } from '@/features/industry/types';
+import { error } from 'console';
+import { ApiError } from 'next/dist/server/api-utils';
+import { ApiErrorResponse } from '@/shared/types/api';
+import { toast } from 'sonner';
 
 interface IndustryAnalysisTableProps {
-  industryId: string;
-  analysis: IndustryAnalysis[];
+  industryId: number;
+  analysis: IndustryAnalysisListItem[];
 }
 
 export default function IndustryAnalysisTable({
   industryId,
   analysis,
 }: IndustryAnalysisTableProps) {
+  const router = useRouter();
+  const { mutate: publish, isPending: isPublishing } = usePublishIndustryAnalysis(
+    Number(industryId),
+  );
+  const { mutate: deleteAnalysis, isPending: isDeleting } = useDeleteIndustryAnalysis(
+    Number(industryId),
+  );
+
+  const handlePublish = (analysisId: number) => {
+    publish(analysisId, {
+      onSuccess: () => router.refresh(),
+      onError: (error: ApiErrorResponse) => {
+        toast.error(error.message || '산업 분석 발행에 실패했습니다.');
+      },
+    });
+  };
+
+  const handleDelete = (analysisId: number) => {
+    deleteAnalysis(analysisId, {
+      onSuccess: () => router.refresh(),
+      onError: (error: ApiErrorResponse) => {
+        toast.error(error.message || '산업 분석 삭제에 실패했습니다.');
+      },
+    });
+  };
+
   return (
     <div className="bg-white rounded-lg border border-ds-grey-200 p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -29,7 +62,6 @@ export default function IndustryAnalysisTable({
       <div className="h-px bg-ds-grey-200" />
 
       <div className="rounded-md border border-ds-grey-200 overflow-hidden">
-        {/* Header Row */}
         <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200">
           <div className="w-25 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">
             분석 연도
@@ -44,26 +76,23 @@ export default function IndustryAnalysisTable({
           <div className="w-48 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">액션</div>
         </div>
 
-        {/* analysis Rows */}
-        {analysis.map((analysisItem, i) => {
-          const isPublished = analysisItem.analysisStatus === 'PUBLISHED';
-          const statusLabel = analysisItem.analysisStatus
-            ? ANALYSIS_STATUS_LABELS[analysisItem.analysisStatus]
-            : '저장됨';
+        {analysis.map((item, i) => {
+          const isPublished = item.analysisStatus === 'PUBLISHED';
+          const statusLabel = ANALYSIS_STATUS_LABELS[item.analysisStatus] ?? '저장됨';
 
           return (
             <div
-              key={analysisItem.analysisId}
+              key={item.analysisId}
               className={`flex items-center h-14 ${i < analysis.length - 1 ? 'border-b border-ds-grey-200' : ''}`}
             >
               <div className="w-25 px-4 text-sm font-semibold text-ds-grey-900 shrink-0">
-                {analysisItem.analysisYear}
+                {item.analysisYear}
               </div>
               <div className="w-37.5 px-4 text-[13px] text-ds-grey-700 shrink-0">
-                {formatDate(analysisItem.createdAt)}
+                {formatDate(item.createdAt)}
               </div>
               <div className="w-37.5 px-4 text-[13px] text-ds-grey-700 shrink-0">
-                {formatDate(analysisItem.updatedAt)}
+                {formatDate(item.updatedAt)}
               </div>
               <div className="w-27.5 px-4 shrink-0">
                 <span
@@ -78,19 +107,26 @@ export default function IndustryAnalysisTable({
               </div>
               <div className="flex-1 px-4 flex items-center gap-1.5">
                 <Link
-                  href={`/industry/${industryId}/analysis/${analysisItem.analysisId}`}
+                  href={`/industry/${industryId}/analysis/${item.analysisId}`}
                   className="inline-flex h-8 items-center justify-center rounded-md border border-ds-grey-200 bg-white px-4 text-sm font-medium text-ds-grey-700 no-underline visited:text-ds-grey-700 hover:bg-ds-grey-50"
                 >
                   상세보기
                 </Link>
                 <Button
                   size="sm"
-                  disabled={isPublished}
+                  disabled={isPublished || isPublishing}
                   className={isPublished ? 'bg-ds-grey-300 hover:bg-ds-grey-300' : 'bg-ds-grey-900'}
+                  onClick={() => handlePublish(item.analysisId)}
                 >
                   발행
                 </Button>
-                <Button size="sm" variant="outline" className="text-ds-badge-red-text">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="text-ds-badge-red-text"
+                  disabled={isDeleting}
+                  onClick={() => handleDelete(item.analysisId)}
+                >
                   삭제
                 </Button>
               </div>

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -8,8 +8,6 @@ import { ANALYSIS_STATUS_LABELS } from '@/features/industry/constants';
 import { formatDate } from '@/shared/lib/formatDate';
 import { usePublishIndustryAnalysis, useDeleteIndustryAnalysis } from '@/features/industry/queries';
 import type { IndustryAnalysisListItem } from '@/features/industry/types';
-import { error } from 'console';
-import { ApiError } from 'next/dist/server/api-utils';
 import { ApiErrorResponse } from '@/shared/types/api';
 import { toast } from 'sonner';
 

--- a/src/features/industry/components/section/IndustryDetailSection.tsx
+++ b/src/features/industry/components/section/IndustryDetailSection.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import TopBar from '@/shared/components/layout/TopBar';
+import { useIndustryAnalysisList, useIndustryCategoryList } from '../../queries';
+import ContentHeader from '@/shared/components/layout/ContentHeader';
+import { Button } from '@/shared/components/ui/button';
+import IndustryBasicInfoCard from '../ui/IndustryBasicInfoCard';
+import IndustryAnalysisTable from './IndustryAnalysisTable';
+import IndustryInfoSideCard from '../ui/IndustryInfoSideCard';
+
+interface IndustryDetailSectionProps {
+  industryId: number;
+}
+export default function IndustryDetailSection({ industryId }: IndustryDetailSectionProps) {
+  const { data: categoryList } = useIndustryCategoryList();
+  const { data: analysisList } = useIndustryAnalysisList(industryId);
+  const label =
+    categoryList?.find((category) => category.industryId === industryId)?.industryName || '산업군';
+  const publishedAnalysisYear = analysisList?.find(
+    (analysis) => analysis.analysisStatus === 'PUBLISHED',
+  )?.analysisYear;
+
+  return (
+    <>
+      <TopBar title="산업군 관리" breadcrumb={`산업군 관리 > ${label}`} />
+
+      <main className="flex-1 overflow-auto bg-ds-grey-100 p-6 flex flex-col gap-5">
+        <ContentHeader
+          title={label}
+          backHref="/industry"
+          actions={
+            <Button variant="outline" className="text-ds-badge-red-text">
+              산업 삭제
+            </Button>
+          }
+        />
+
+        <div className="flex gap-5 items-start">
+          <div className="flex-1 flex flex-col gap-4">
+            <IndustryBasicInfoCard industryId={industryId} label={label} />
+            <IndustryAnalysisTable industryId={industryId} analysis={analysisList || []} />
+          </div>
+          <IndustryInfoSideCard
+            analysisCount={analysisList?.length || 0}
+            publishedAnalysisYear={publishedAnalysisYear}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/features/industry/components/section/IndustryDetailSection.tsx
+++ b/src/features/industry/components/section/IndustryDetailSection.tsx
@@ -3,7 +3,6 @@
 import TopBar from '@/shared/components/layout/TopBar';
 import { useIndustryAnalysisList, useIndustryCategoryList } from '../../queries';
 import ContentHeader from '@/shared/components/layout/ContentHeader';
-import { Button } from '@/shared/components/ui/button';
 import IndustryBasicInfoCard from '../ui/IndustryBasicInfoCard';
 import IndustryAnalysisTable from './IndustryAnalysisTable';
 import IndustryInfoSideCard from '../ui/IndustryInfoSideCard';
@@ -25,15 +24,7 @@ export default function IndustryDetailSection({ industryId }: IndustryDetailSect
       <TopBar title="산업군 관리" breadcrumb={`산업군 관리 > ${label}`} />
 
       <main className="flex-1 overflow-auto bg-ds-grey-100 p-6 flex flex-col gap-5">
-        <ContentHeader
-          title={label}
-          backHref="/industry"
-          actions={
-            <Button variant="outline" className="text-ds-badge-red-text">
-              산업 삭제
-            </Button>
-          }
-        />
+        <ContentHeader title={label} backHref="/industry" />
 
         <div className="flex gap-5 items-start">
           <div className="flex-1 flex flex-col gap-4">

--- a/src/features/industry/components/section/IndustryList.tsx
+++ b/src/features/industry/components/section/IndustryList.tsx
@@ -1,24 +1,39 @@
-import { mockIndustries, mockIndustriesAnalysis } from '@/mocks';
+'use client';
+
+import { useIndustryCategoryList } from '@/features/industry/queries';
 import IndustryCard from '@/features/industry/components/ui/IndustryCard';
 
 export default function IndustryList() {
+  const { data: categories, isLoading, isError, error } = useIndustryCategoryList();
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-4 gap-3">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="h-35 rounded-[10px] bg-ds-grey-200 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !categories) {
+    return (
+      <p className="text-sm text-ds-grey-500">
+        산업 카테고리를 불러오지 못했습니다. {error?.message}
+      </p>
+    );
+  }
+
   return (
     <div className="grid grid-cols-4 gap-3">
-      {/* TODO: 산업 카테고리 목록 조회 API 연결하기. (/api/v1/admin/industries)*/}
-      {mockIndustries.map((item) => {
-        const analysisCount = mockIndustriesAnalysis.filter(
-          (v) => v.industryId === item.industryId,
-        ).length;
-
-        return (
-          <IndustryCard
-            key={item.industryId}
-            industryId={item.industryId}
-            label={item.name}
-            analysisCount={analysisCount}
-          />
-        );
-      })}
+      {categories.map((item) => (
+        <IndustryCard
+          key={item.industryId}
+          industryId={item.industryId}
+          label={item.industryName}
+          analysisCount={item.analysisCount}
+        />
+      ))}
     </div>
   );
 }

--- a/src/features/industry/components/ui/IndustryAddButton.tsx
+++ b/src/features/industry/components/ui/IndustryAddButton.tsx
@@ -15,12 +15,38 @@ import {
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import { Separator } from '@/shared/components/ui/separator';
+import { toast } from 'sonner';
+import { useCreateIndustryCategory } from '@/features/industry/queries';
 
 export default function IndustryAddButton() {
   const [isOpen, setIsOpen] = useState(false);
+  const [industryName, setIndustryName] = useState('');
+  const { mutate: createCategory, isPending } = useCreateIndustryCategory();
+
+  function handleSubmit() {
+    if (!industryName.trim()) return;
+    createCategory(
+      { industryName: industryName.trim() },
+      {
+        onSuccess: () => {
+          toast.success('산업군이 등록되었습니다.');
+          setIsOpen(false);
+          setIndustryName('');
+        },
+        onError: (error) => {
+          toast.error(error.message || '산업군 등록에 실패했습니다.');
+        },
+      },
+    );
+  }
+
+  function handleOpenChange(open: boolean) {
+    setIsOpen(open);
+    if (!open) setIndustryName('');
+  }
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button className="gap-1.5">
           <Plus size={16} />
@@ -53,6 +79,8 @@ export default function IndustryAddButton() {
             type="text"
             placeholder="예) 인공지능 / AI"
             className="border-ds-grey-200 bg-white text-sm text-ds-grey-900"
+            value={industryName}
+            onChange={(e) => setIndustryName(e.target.value)}
           />
         </div>
 
@@ -67,8 +95,9 @@ export default function IndustryAddButton() {
               취소
             </Button>
           </DialogClose>
-          {/* TODO: 산업 카테고리 생성 API 호출 위치 (/api/v1/admin/industries) */}
-          <Button>등록</Button>
+          <Button onClick={handleSubmit} disabled={!industryName.trim() || isPending}>
+            등록
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/features/industry/components/ui/IndustryAddButton.tsx
+++ b/src/features/industry/components/ui/IndustryAddButton.tsx
@@ -17,6 +17,7 @@ import { Label } from '@/shared/components/ui/label';
 import { Separator } from '@/shared/components/ui/separator';
 import { toast } from 'sonner';
 import { useCreateIndustryCategory } from '@/features/industry/queries';
+import { ApiErrorResponse } from '@/shared/types/api';
 
 export default function IndustryAddButton() {
   const [isOpen, setIsOpen] = useState(false);
@@ -33,7 +34,7 @@ export default function IndustryAddButton() {
           setIsOpen(false);
           setIndustryName('');
         },
-        onError: (error) => {
+        onError: (error: ApiErrorResponse) => {
           toast.error(error.message || '산업군 등록에 실패했습니다.');
         },
       },

--- a/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
+++ b/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
@@ -16,10 +16,17 @@ interface IndustryBasicInfoCardProps {
 export default function IndustryBasicInfoCard({ industryId, label }: IndustryBasicInfoCardProps) {
   const [industryName, setIndustryName] = useState(label);
   const { mutate: updateCategory, isPending } = useUpdateIndustryCategory(industryId);
+  const trimmedIndustryName = industryName.trim();
 
   const handleSave = () => {
+    if (trimmedIndustryName.length === 0) {
+      toast.error('산업명은 공백일 수 없습니다.');
+
+      return;
+    }
+
     updateCategory(
-      { industryName },
+      { industryName: trimmedIndustryName },
       {
         onSuccess: () => {
           toast.success('산업군 정보가 업데이트되었습니다.');
@@ -37,7 +44,9 @@ export default function IndustryBasicInfoCard({ industryId, label }: IndustryBas
         <span className="text-[15px] font-semibold text-ds-grey-900">기본 정보</span>
         <Button
           className="bg-ds-grey-900 text-white hover:bg-ds-grey-800"
-          disabled={isPending || industryName.trim() === label}
+          disabled={
+            isPending || trimmedIndustryName.length === 0 || trimmedIndustryName === label.trim()
+          }
           onClick={handleSave}
         >
           {isPending ? '저장 중...' : '저장'}

--- a/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
+++ b/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
@@ -16,17 +16,16 @@ interface IndustryBasicInfoCardProps {
 export default function IndustryBasicInfoCard({ industryId, label }: IndustryBasicInfoCardProps) {
   const [industryName, setIndustryName] = useState(label);
   const { mutate: updateCategory, isPending } = useUpdateIndustryCategory(industryId);
-  const trimmedIndustryName = industryName.trim();
 
   const handleSave = () => {
-    if (trimmedIndustryName.length === 0) {
+    if (industryName.trim().length === 0) {
       toast.error('산업명은 공백일 수 없습니다.');
 
       return;
     }
 
     updateCategory(
-      { industryName: trimmedIndustryName },
+      { industryName },
       {
         onSuccess: () => {
           toast.success('산업군 정보가 업데이트되었습니다.');
@@ -45,7 +44,7 @@ export default function IndustryBasicInfoCard({ industryId, label }: IndustryBas
         <Button
           className="bg-ds-grey-900 text-white hover:bg-ds-grey-800"
           disabled={
-            isPending || trimmedIndustryName.length === 0 || trimmedIndustryName === label.trim()
+            isPending || industryName.trim().length === 0 || industryName.trim() === label.trim()
           }
           onClick={handleSave}
         >

--- a/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
+++ b/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
@@ -23,7 +23,7 @@ export default function IndustryBasicInfoCard({ industryId, label }: IndustryBas
         onSuccess: () => {
           toast.success('산업군 정보가 업데이트되었습니다.');
         },
-        onError: (error) => {
+        onError: () => {
           toast.error('산업군 정보 업데이트에 실패했습니다.');
         },
       },

--- a/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
+++ b/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
@@ -1,24 +1,54 @@
+'use client';
+
+import { useState } from 'react';
 import { Button } from '@/shared/components/ui/button';
 import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
+import { useUpdateIndustryCategory } from '@/features/industry/queries';
+import { toast } from 'sonner';
 
 interface IndustryBasicInfoCardProps {
+  industryId: number;
   label: string;
 }
 
-export default function IndustryBasicInfoCard({ label }: IndustryBasicInfoCardProps) {
+export default function IndustryBasicInfoCard({ industryId, label }: IndustryBasicInfoCardProps) {
+  const [industryName, setIndustryName] = useState(label);
+  const { mutate: updateCategory, isPending } = useUpdateIndustryCategory(industryId);
+
+  const handleSave = () => {
+    updateCategory(
+      { industryName },
+      {
+        onSuccess: () => {
+          toast.success('산업군 정보가 업데이트되었습니다.');
+        },
+        onError: (error) => {
+          toast.error('산업군 정보 업데이트에 실패했습니다.');
+        },
+      },
+    );
+  };
+
   return (
     <div className="bg-white rounded-lg border border-ds-grey-200 p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <span className="text-[15px] font-semibold text-ds-grey-900">기본 정보</span>
-        <Button className="bg-ds-grey-900 text-white hover:bg-ds-grey-800">저장</Button>
+        <Button
+          className="bg-ds-grey-900 text-white hover:bg-ds-grey-800"
+          disabled={isPending || industryName.trim() === label}
+          onClick={handleSave}
+        >
+          {isPending ? '저장 중...' : '저장'}
+        </Button>
       </div>
       <div className="h-px bg-ds-grey-200" />
       <div className="flex flex-col gap-1.5">
         <Label className="text-sm font-medium text-ds-grey-900">산업명 *</Label>
         <Input
           type="text"
-          defaultValue={label}
+          value={industryName}
+          onChange={(e) => setIndustryName(e.target.value)}
           className="h-10 border-ds-grey-200 text-ds-grey-900"
         />
       </div>

--- a/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
+++ b/src/features/industry/components/ui/IndustryBasicInfoCard.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/shared/components/ui/input';
 import { Label } from '@/shared/components/ui/label';
 import { useUpdateIndustryCategory } from '@/features/industry/queries';
 import { toast } from 'sonner';
+import { ApiErrorResponse } from '@/shared/types/api';
 
 interface IndustryBasicInfoCardProps {
   industryId: number;
@@ -23,8 +24,8 @@ export default function IndustryBasicInfoCard({ industryId, label }: IndustryBas
         onSuccess: () => {
           toast.success('산업군 정보가 업데이트되었습니다.');
         },
-        onError: () => {
-          toast.error('산업군 정보 업데이트에 실패했습니다.');
+        onError: (error: ApiErrorResponse) => {
+          toast.error(error.message || '산업군 정보 업데이트에 실패했습니다.');
         },
       },
     );

--- a/src/features/industry/components/ui/IndustryInfoSideCard.tsx
+++ b/src/features/industry/components/ui/IndustryInfoSideCard.tsx
@@ -1,13 +1,13 @@
-import type { IndustryAnalysis } from '@/features/industry/types';
+import type { IndustryAnalysisListItem } from '@/features/industry/types';
 
 interface IndustryInfoSideCardProps {
   analysisCount: number;
-  publishedAnalysis?: IndustryAnalysis;
+  publishedAnalysisYear?: number;
 }
 
 export default function IndustryInfoSideCard({
   analysisCount,
-  publishedAnalysis,
+  publishedAnalysisYear,
 }: IndustryInfoSideCardProps) {
   return (
     <div className="w-70 flex flex-col gap-3">
@@ -20,9 +20,9 @@ export default function IndustryInfoSideCard({
         </div>
         <div className="flex justify-between items-center text-[13px]">
           <span className="text-ds-grey-600">최신 발행 버전</span>
-          {publishedAnalysis ? (
+          {publishedAnalysisYear ? (
             <span className="inline-flex px-2 py-0.5 rounded-md text-xs font-medium bg-ds-badge-green-bg text-ds-badge-green-text">
-              {publishedAnalysis.analysisYear}
+              {publishedAnalysisYear}
             </span>
           ) : (
             <span className="text-ds-grey-500">-</span>

--- a/src/features/industry/components/ui/IndustryInfoSideCard.tsx
+++ b/src/features/industry/components/ui/IndustryInfoSideCard.tsx
@@ -1,5 +1,3 @@
-import type { IndustryAnalysisListItem } from '@/features/industry/types';
-
 interface IndustryInfoSideCardProps {
   analysisCount: number;
   publishedAnalysisYear?: number;

--- a/src/features/industry/queries.ts
+++ b/src/features/industry/queries.ts
@@ -1,12 +1,10 @@
-'use client';
-
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, queryOptions } from '@tanstack/react-query';
 import {
   getIndustryCategoryList,
-  createIndustryCategory,
-  updateIndustryCategory,
   getIndustryAnalysisList,
   getIndustryAnalysis,
+  createIndustryCategory,
+  updateIndustryCategory,
   createIndustryAnalysis,
   publishIndustryAnalysis,
   deleteIndustryAnalysis,
@@ -16,12 +14,7 @@ import type {
   UpdateIndustryCategoryRequest,
   CreateIndustryAnalysisRequest,
 } from '@/features/industry/types';
-
-function toQueryError(result: { code: string; message: string }) {
-  const error = new Error(result.message || '요청 처리에 실패했습니다.');
-  error.name = result.code || 'API_ERROR';
-  return error;
-}
+import { ApiErrorResponse } from '@/shared/types/api';
 
 export const industryQueryKeys = {
   categoryList: ['industry', 'categories'] as const,
@@ -30,34 +23,38 @@ export const industryQueryKeys = {
 };
 
 // 산업 카테고리 목록 조회 Query Options
-export const industryCategoryListQueryOptions = {
+export const industryCategoryListQueryOptions = queryOptions({
   queryKey: industryQueryKeys.categoryList,
   queryFn: async () => {
     const result = await getIndustryCategoryList();
-    if (!result.success) throw toQueryError(result);
+    if (!result.success) return Promise.reject(result);
     return result.data;
   },
-};
+});
 
 // 산업 분석 목록 조회 Query Options
-export const industryAnalysisListQueryOptions = (industryId: number) => ({
-  queryKey: industryQueryKeys.analysisList(industryId),
-  queryFn: async () => {
-    const result = await getIndustryAnalysisList(industryId);
-    if (!result.success) throw toQueryError(result);
-    return result.data;
-  },
-});
+export const industryAnalysisListQueryOptions = (industryId: number) =>
+  queryOptions({
+    queryKey: industryQueryKeys.analysisList(industryId),
+    queryFn: async () => {
+      const result = await getIndustryAnalysisList(industryId);
+      if (!result.success) return Promise.reject(result);
+      return result.data;
+    },
+  });
 
 // 산업 분석 단건 조회 Query Options
-export const industryAnalysisQueryOptions = (analysisId: number) => ({
-  queryKey: industryQueryKeys.analysis(analysisId),
-  queryFn: async () => {
-    const result = await getIndustryAnalysis(analysisId);
-    if (!result.success) throw toQueryError(result);
-    return result.data;
-  },
-});
+export const industryAnalysisQueryOptions = (analysisId: number) =>
+  queryOptions({
+    queryKey: industryQueryKeys.analysis(analysisId),
+    queryFn: async () => {
+      const result = await getIndustryAnalysis(analysisId);
+      if (!result.success) return Promise.reject(result);
+      return result.data;
+    },
+  });
+
+// 조회 useQuery 훅들
 
 // 산업 카테고리 목록 조회 useQuery
 export function useIndustryCategoryList() {
@@ -72,13 +69,15 @@ export function useIndustryAnalysisList(industryId: number) {
   });
 }
 
-// 산업 분석 단건 조회 useQuery
+// 산업 분석 단건 조회 useQuery (페이지 진입 시 Prefetch)
 export function useIndustryAnalysis(analysisId: number) {
   return useQuery({
     ...industryAnalysisQueryOptions(analysisId),
     enabled: Number.isFinite(analysisId) && analysisId > 0,
   });
 }
+
+// 변이 useMutation 훅들
 
 // 산업 카테고리 생성 useMutation
 export function useCreateIndustryCategory() {
@@ -87,11 +86,14 @@ export function useCreateIndustryCategory() {
   return useMutation({
     mutationFn: async (data: CreateIndustryCategoryRequest) => {
       const result = await createIndustryCategory(data);
-      if (!result.success) throw toQueryError(result);
+      if (!result.success) return Promise.reject(result);
       return result.data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.categoryList });
+    },
+    onError: (error: ApiErrorResponse) => {
+      console.error('산업 카테고리 생성 실패:', error);
     },
   });
 }
@@ -103,11 +105,14 @@ export function useUpdateIndustryCategory(industryId: number) {
   return useMutation({
     mutationFn: async (data: UpdateIndustryCategoryRequest) => {
       const result = await updateIndustryCategory(industryId, data);
-      if (!result.success) throw toQueryError(result);
+      if (!result.success) return Promise.reject(result);
       return result.data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.categoryList });
+    },
+    onError: (error: ApiErrorResponse) => {
+      console.error('산업 카테고리 수정 실패:', error);
     },
   });
 }
@@ -119,7 +124,7 @@ export function useCreateIndustryAnalysis(industryId: number) {
   return useMutation({
     mutationFn: async (data: CreateIndustryAnalysisRequest) => {
       const result = await createIndustryAnalysis(industryId, data);
-      if (!result.success) throw toQueryError(result);
+      if (!result.success) return Promise.reject(result);
       return result.data;
     },
     onSuccess: (createdAnalysis) => {
@@ -128,6 +133,9 @@ export function useCreateIndustryAnalysis(industryId: number) {
       queryClient.removeQueries({
         queryKey: industryQueryKeys.analysis(createdAnalysis.analysisId),
       });
+    },
+    onError: (error: ApiErrorResponse) => {
+      console.error('산업 분석 생성 실패:', error);
     },
   });
 }
@@ -139,12 +147,15 @@ export function usePublishIndustryAnalysis(industryId: number) {
   return useMutation({
     mutationFn: async (analysisId: number) => {
       const result = await publishIndustryAnalysis(analysisId);
-      if (!result.success) throw toQueryError(result);
+      if (!result.success) return Promise.reject(result);
       return result.data;
     },
     onSuccess: (_, analysisId) => {
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.analysisList(industryId) });
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.analysis(analysisId) });
+    },
+    onError: (error: ApiErrorResponse) => {
+      console.error('산업 분석 발행 실패:', error);
     },
   });
 }
@@ -156,13 +167,16 @@ export function useDeleteIndustryAnalysis(industryId: number) {
   return useMutation({
     mutationFn: async (analysisId: number) => {
       const result = await deleteIndustryAnalysis(analysisId);
-      if (!result.success) throw toQueryError(result);
+      if (!result.success) return Promise.reject(result);
       return result.data;
     },
     onSuccess: (_, analysisId) => {
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.analysisList(industryId) });
       queryClient.invalidateQueries({ queryKey: industryQueryKeys.categoryList });
       queryClient.removeQueries({ queryKey: industryQueryKeys.analysis(analysisId) });
+    },
+    onError: (error: ApiErrorResponse) => {
+      console.error('산업 분석 삭제 실패:', error);
     },
   });
 }

--- a/src/features/industry/utils/getIndustryIconConfig.tsx
+++ b/src/features/industry/utils/getIndustryIconConfig.tsx
@@ -21,6 +21,10 @@ export const INDUSTRY_CATEGORY_ICON_CONFIG: Record<string, IndustryIconConfig> =
   return acc;
 }, {});
 
-const { label: _otherLabel, ...defaultIndustryIconConfig } = INDUSTRY_CONFIG.OTHER;
+const defaultIndustryIconConfig: IndustryIconConfig = {
+  icon: INDUSTRY_CONFIG.OTHER.icon,
+  iconColor: INDUSTRY_CONFIG.OTHER.iconColor,
+  bgColor: INDUSTRY_CONFIG.OTHER.bgColor,
+};
 
 export const DEFAULT_INDUSTRY_ICON_CONFIG: IndustryIconConfig = defaultIndustryIconConfig;

--- a/src/shared/components/layout/Sidebar.tsx
+++ b/src/shared/components/layout/Sidebar.tsx
@@ -2,14 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  LayoutDashboard,
-  Building2,
-  Briefcase,
-  FileText,
-  ChevronRight,
-  LogOut,
-} from 'lucide-react';
+import { Building2, Briefcase, FileText, ChevronRight, LogOut } from 'lucide-react';
 import { Button } from '@/shared/components/ui/button';
 import { Separator } from '@/shared/components/ui/separator';
 import { cn } from '@/shared/lib/cn';

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -1,54 +1,52 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
 
-import { cn } from "@/shared/lib/cn"
+import { cn } from '@/shared/lib/cn';
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "cursor-pointer inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant = 'default',
+  size = 'default',
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : 'button';
 
   return (
     <Comp
@@ -58,7 +56,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/shared/lib/cn';
 
 const buttonVariants = cva(
-  "cursor-pointer inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  'cursor-pointer inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## 작업 내용

- 서버-클라이언트 경계(useQuery 호출 위치), prefetch/hydration 구조, 액션(생성/수정/발행/삭제) 연동을 정리
- 산업군 목록/상세/분석상세 페이지에 QueryClient prefetch + HydrationBoundary 적용
- 산업군 도메인 쿼리 구조를 queryOptions 기반으로 정리
- 산업군 목록 조회를 mock 데이터에서 실제 query 기반으로 전환
- 산업군 추가/수정 기능을 mutation으로 연결
- 분석 버전 생성/발행/삭제 기능을 mutation으로 연결
- 상세 화면 액션 컴포넌트 분리 및 섹션 컴포넌트 구조화
- 공통 토스트(Toaster) 루트 레이아웃 등록
아이콘 기본 설정 타입 정합성 보정


## 리뷰 필요

- 기능 동작 확인 (목록/상세/버전 추가/발행/삭제)
-  서버-클라이언트 경계 오류(useQuery on server) 해소
-  lint 에러 없음
-  QA: 실제 API 환경에서 산업군/분석 데이터 시나리오 재확인


close #36
