### PR TITLE
refactor: httpClient 디버그 로깅 분리 및 응답 추적 보강

### DIFF
--- a/src/shared/api/httpClient.debug.ts
+++ b/src/shared/api/httpClient.debug.ts
@@ -1,0 +1,257 @@
+import type { ApiErrorDetail } from '@/shared/types/api';
+
+const ENABLE_FETCH_DEBUG = process.env.NODE_ENV !== 'production';
+
+const LOG_LABELS = {
+  REQUEST_SUCCESS: 'Request success (요청 성공)',
+  REQUEST_FAILED: 'Request failed (요청 실패)',
+  API_ERROR_CODE: 'API returned failure payload (응답 실패 payload)',
+  UNEXPECTED_ERROR: 'Unexpected error (예상치 못한 오류)',
+} as const;
+
+type LogSchema = {
+  '요청(request)': {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+  };
+  '응답(response)': {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+    bodyRaw?: string;
+    bodyJson?: unknown;
+  };
+  '오류(error)'?: {
+    name?: string;
+    message: string;
+    stack?: string;
+    cause?: unknown;
+  };
+};
+
+export type FetchDebugInfo = {
+  url: string;
+  method: string;
+  requestHeaders: Record<string, string>;
+  requestBodyPreview?: string;
+  status?: number;
+  statusText?: string;
+  responseHeaders?: Record<string, string>;
+  responseBodyRaw?: string;
+  responseBodyJson?: unknown;
+};
+
+export type ParsedApiResult<T> = {
+  success?: boolean;
+  code?: string;
+  message?: string;
+  data?: T | null;
+  errors?: ApiErrorDetail[];
+  timestamp?: string;
+};
+
+function debugLog(level: 'info' | 'error', label: string, payload: unknown): void {
+  if (!ENABLE_FETCH_DEBUG) return;
+  console[level](label, payload);
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+function maskSensitiveHeaders(headers: Record<string, string>): Record<string, string> {
+  const masked = { ...headers };
+
+  const mask = (value?: string | null) =>
+    value ? value.replace(/^(.{0,8}).+$/, '$1***') : (value ?? '');
+
+  if (masked.Authorization) masked.Authorization = mask(masked.Authorization);
+  if (masked.authorization) masked.authorization = mask(masked.authorization);
+
+  if (masked.Cookie) masked.Cookie = '***';
+  if (masked.cookie) masked.cookie = '***';
+
+  if (masked['Set-Cookie']) masked['Set-Cookie'] = '***';
+  if (masked['set-cookie']) masked['set-cookie'] = '***';
+
+  return masked;
+}
+
+function normalizeErrors(errors: unknown): ApiErrorDetail[] {
+  if (!Array.isArray(errors)) return [];
+  return errors as ApiErrorDetail[];
+}
+
+function buildBodyPreview(body: RequestInit['body'], isFormData: boolean): string | undefined {
+  if (!body) return undefined;
+
+  if (isFormData && body instanceof FormData) {
+    const keys = Array.from(body.keys());
+    return `FormData(keys=${JSON.stringify(keys)})`;
+  }
+
+  if (typeof body === 'string') {
+    return body.length > 2000 ? `${body.slice(0, 2000)}...(truncated)` : body;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return `ArrayBuffer(byteLength=${body.byteLength})`;
+  }
+
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return `Blob(size=${body.size}, type=${body.type})`;
+  }
+
+  return `Body(type=${Object.prototype.toString.call(body)})`;
+}
+
+function buildLogPayload(debugInfo: FetchDebugInfo, extra?: LogSchema['오류(error)']): LogSchema {
+  return {
+    '요청(request)': {
+      url: debugInfo.url,
+      method: debugInfo.method,
+      headers: debugInfo.requestHeaders,
+      body: debugInfo.requestBodyPreview,
+    },
+    '응답(response)': {
+      status: debugInfo.status,
+      statusText: debugInfo.statusText,
+      headers: debugInfo.responseHeaders,
+      bodyRaw: debugInfo.responseBodyRaw,
+      bodyJson: debugInfo.responseBodyJson,
+    },
+    ...(extra
+      ? {
+          '오류(error)': extra,
+        }
+      : {}),
+  };
+}
+
+export function createFetchDebugInfo(
+  url: string,
+  options: RequestInit,
+  headers: Headers,
+  isFormData: boolean,
+): FetchDebugInfo {
+  return {
+    url,
+    method: (options.method || 'GET').toUpperCase(),
+    requestHeaders: maskSensitiveHeaders(headersToObject(headers)),
+    requestBodyPreview: buildBodyPreview(options.body, isFormData),
+  };
+}
+
+export function fillResponseDebugInfo(debugInfo: FetchDebugInfo, response: Response): void {
+  debugInfo.status = response.status;
+  debugInfo.statusText = response.statusText;
+  debugInfo.responseHeaders = maskSensitiveHeaders(headersToObject(response.headers));
+}
+
+export async function parseResponseBody<T>(
+  response: Response,
+  debugInfo: FetchDebugInfo,
+): Promise<ParsedApiResult<T>> {
+  const raw = await response.text();
+
+  debugInfo.responseBodyRaw = raw.length > 8000 ? `${raw.slice(0, 8000)}...(truncated)` : raw;
+
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const parsed = raw ? JSON.parse(raw) : null;
+      debugInfo.responseBodyJson = parsed;
+
+      return {
+        success: parsed?.success,
+        code: parsed?.code,
+        message: parsed?.message,
+        data: parsed?.data ?? null,
+        errors: normalizeErrors(parsed?.errors),
+        timestamp: parsed?.timestamp,
+      };
+    } catch (error) {
+      debugInfo.responseBodyJson = { parseError: String(error) };
+
+      return {
+        success: false,
+        code: 'INVALID_JSON',
+        message: '응답 JSON 파싱에 실패했습니다.',
+        data: null,
+        errors: [],
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
+  const fallback: ParsedApiResult<T> = {
+    success: false,
+    code: 'NON_JSON_RESPONSE',
+    message: raw || 'JSON 형식이 아닌 응답입니다.',
+    data: null,
+    errors: [],
+    timestamp: new Date().toISOString(),
+  };
+
+  debugInfo.responseBodyJson = fallback;
+  return fallback;
+}
+
+export function logRequestSuccess(debugInfo: FetchDebugInfo): void {
+  debugLog(
+    'info',
+    LOG_LABELS.REQUEST_SUCCESS,
+    `${debugInfo.method} ${debugInfo.url} -> ${debugInfo.status}`,
+  );
+}
+
+export function logRequestFailed(debugInfo: FetchDebugInfo): void {
+  debugLog('error', LOG_LABELS.REQUEST_FAILED, buildLogPayload(debugInfo));
+}
+
+export function logApiFailure(debugInfo: FetchDebugInfo, message?: string): void {
+  debugLog(
+    'error',
+    LOG_LABELS.API_ERROR_CODE,
+    buildLogPayload(debugInfo, {
+      name: 'ApiFailurePayload',
+      message: message || 'success=false 응답이 반환되었습니다.',
+    }),
+  );
+}
+
+export function logUnexpectedError(debugInfo: FetchDebugInfo, error: unknown): void {
+  const errObj =
+    error instanceof Error
+      ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack,
+          cause: error.cause,
+        }
+      : {
+          message: String(error),
+        };
+
+  debugLog('error', LOG_LABELS.UNEXPECTED_ERROR, buildLogPayload(debugInfo, errObj));
+}
+
+export function logConfigError(endpoint: string, options: RequestInit = {}): void {
+  const debugInfo: FetchDebugInfo = {
+    url: endpoint,
+    method: (options.method || 'GET').toUpperCase(),
+    requestHeaders: {},
+  };
+
+  debugLog(
+    'error',
+    LOG_LABELS.UNEXPECTED_ERROR,
+    buildLogPayload(debugInfo, {
+      name: 'ConfigError',
+      message: 'NEXT_PUBLIC_API_URL이 설정되지 않았습니다.',
+    }),
+  );
+}

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -1,71 +1,182 @@
-import { cookies } from 'next/headers';
-import { ApiResponse, ApiErrorResponse, ApiSuccessResponse } from '@/shared/types/api';
+import type {
+  ApiResponse,
+  ApiErrorResponse,
+  ApiSuccessResponse,
+  ApiErrorDetail,
+} from '@/shared/types/api';
+import {
+  createFetchDebugInfo,
+  fillResponseDebugInfo,
+  logApiFailure,
+  logConfigError,
+  logRequestFailed,
+  logRequestSuccess,
+  logUnexpectedError,
+  parseResponseBody,
+} from '@/shared/api/httpClient.debug';
 
 const BASE_API_URL = process.env.NEXT_PUBLIC_API_URL;
+// 로컬 테스트를 위한 14일 기간의 엑세스 토큰
+const ACCESS_TOKEN = process.env.DEV_ACCESS_TOKEN;
 
 /**
  * 내부 헬퍼 함수: 예상치 못한 시스템/네트워크 에러를 표준 실패 포맷으로 규격화
  */
-function createErrorResponse(code: string, message: string): ApiErrorResponse {
+function createErrorResponse(
+  code: string,
+  message: string,
+  errors: ApiErrorDetail[] = [],
+  timestamp: string = new Date().toISOString(),
+): ApiErrorResponse {
   return {
     success: false,
     code,
     message,
     data: null,
-    errors: [],
-    timestamp: new Date().toISOString(),
+    errors,
+    timestamp,
   };
+}
+
+function createSuccessResponse<T>(
+  data: T,
+  code: string = 'SUCCESS',
+  message: string = '요청에 성공했습니다.',
+  timestamp: string = new Date().toISOString(),
+): ApiSuccessResponse<T> {
+  return {
+    success: true,
+    code,
+    message,
+    data,
+    timestamp,
+  };
+}
+
+async function requestApi<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  config?: {
+    requireAuth?: boolean;
+    accessToken?: string;
+    sessionExpiredMessage?: string;
+  },
+): Promise<ApiResponse<T>> {
+  const requireAuth = config?.requireAuth ?? false;
+  const accessToken = config?.accessToken;
+  const sessionExpiredMessage =
+    config?.sessionExpiredMessage ?? '세션이 만료되었습니다. 다시 로그인해 주세요.';
+
+  if (!BASE_API_URL && !endpoint.startsWith('http')) {
+    logConfigError(endpoint, options);
+    return createErrorResponse('CONFIG_ERROR', 'NEXT_PUBLIC_API_URL이 설정되지 않았습니다.');
+  }
+
+  if (requireAuth && !accessToken) {
+    return createErrorResponse('SESSION_EXPIRED', '접근 권한이 없습니다. 다시 로그인해 주세요.');
+  }
+
+  const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
+
+  const headers = new Headers(options.headers);
+
+  if (requireAuth && accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  if (!isFormData) {
+    if (!headers.get('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+  } else {
+    headers.delete('Content-Type');
+  }
+
+  const url = endpoint.startsWith('http') ? endpoint : `${BASE_API_URL}${endpoint}`;
+  const debugInfo = createFetchDebugInfo(url, options, headers, isFormData);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      method: options.method || 'GET',
+      headers,
+    });
+
+    fillResponseDebugInfo(debugInfo, response);
+
+    const result = await parseResponseBody<T>(response, debugInfo);
+
+    if (!response.ok) {
+      logRequestFailed(debugInfo);
+
+      if (response.status === 401) {
+        return createErrorResponse(
+          'SESSION_EXPIRED',
+          sessionExpiredMessage,
+          result.errors ?? [],
+          result.timestamp,
+        );
+      }
+
+      return createErrorResponse(
+        result.code || 'HTTP_ERROR',
+        result.message || '요청 처리에 실패했습니다.',
+        result.errors ?? [],
+        result.timestamp,
+      );
+    }
+
+    if (result.success !== true) {
+      logApiFailure(debugInfo, result.message);
+
+      return createErrorResponse(
+        result.code || 'HTTP_ERROR',
+        result.message || '요청 처리에 실패했습니다.',
+        result.errors ?? [],
+        result.timestamp,
+      );
+    }
+
+    logRequestSuccess(debugInfo);
+
+    return createSuccessResponse<T>(
+      result.data as T,
+      result.code ?? 'SUCCESS',
+      result.message ?? '요청에 성공했습니다.',
+      result.timestamp ?? new Date().toISOString(),
+    );
+  } catch (error) {
+    logUnexpectedError(debugInfo, error);
+    return createErrorResponse('NETWORK_ERROR', '서버와의 통신에 실패했습니다.');
+  }
 }
 
 /**
  * [Token O] 인증이 필요한 공통 Fetch
  * - proxy.ts에서 이미 갱신 처리를 완료했다고 가정
  * - 여기서 401이 발생하면 토큰이 완전히 만료된 상태이므로 세션 만료 에러를 반환
+ *
+ * TODO:
+ * - 현재는 로컬 테스트를 위해 DEV_ACCESS_TOKEN을 사용합니다.
+ * - 추후 실환경에서는 cookies() 기반 accessToken 조회 방식으로 전환할 수 있습니다.
  */
 export async function privateFetch<T>(
   endpoint: string,
   options: RequestInit = {},
 ): Promise<ApiResponse<T>> {
-  const cookieStore = await cookies();
-  const currentToken = cookieStore.get('accessToken')?.value;
+  // 추후 실환경 전환 시 사용 가능
+  // const cookieStore = await cookies();
+  // const currentToken = cookieStore.get('accessToken')?.value;
 
-  if (!currentToken) {
-    return createErrorResponse('SESSION_EXPIRED', '접근 권한이 없습니다. 다시 로그인해 주세요.');
-  }
+  // if (!currentToken) {
+  //   return createErrorResponse('SESSION_EXPIRED', '접근 권한이 없습니다. 다시 로그인해 주세요.');
+  // }
 
-  try {
-    const response = await fetch(`${BASE_API_URL}${endpoint}`, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${currentToken}`,
-        ...options.headers,
-      },
-    });
-
-    const result = await response.json();
-
-    if (!response.ok || !result.success) {
-      if (response.status === 401) {
-        return createErrorResponse(
-          'SESSION_EXPIRED',
-          '세션이 만료되었습니다. 다시 로그인해 주세요.',
-        );
-      }
-
-      return {
-        success: false,
-        code: result.code || 'HTTP_ERROR',
-        message: result.message || '요청 처리에 실패했습니다.',
-        data: null,
-        errors: result.errors || [],
-      };
-    }
-
-    return result as ApiSuccessResponse<T>;
-  } catch (error) {
-    return createErrorResponse('NETWORK_ERROR', '서버와의 통신에 실패했습니다.');
-  }
+  return requestApi<T>(endpoint, options, {
+    requireAuth: true,
+    accessToken: ACCESS_TOKEN, // currentToken
+    sessionExpiredMessage: '세션이 만료되었습니다. 다시 로그인해 주세요.',
+  });
 }
 
 /**
@@ -75,29 +186,7 @@ export async function publicFetch<T>(
   endpoint: string,
   options: RequestInit = {},
 ): Promise<ApiResponse<T>> {
-  try {
-    const response = await fetch(`${BASE_API_URL}${endpoint}`, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
-    });
-
-    const result = await response.json();
-
-    if (!response.ok || !result.success) {
-      return {
-        success: false,
-        code: result.code || 'HTTP_ERROR',
-        message: result.message || '요청 처리에 실패했습니다.',
-        data: null,
-        errors: result.errors || [],
-      };
-    }
-
-    return result as ApiSuccessResponse<T>;
-  } catch (error) {
-    return createErrorResponse('NETWORK_ERROR', '서버와의 통신에 실패했습니다.');
-  }
+  return requestApi<T>(endpoint, options, {
+    requireAuth: false,
+  });
 }


### PR DESCRIPTION
## 작업 내용

- `httpClient` 요청 흐름에 디버그 로깅 연결
- 요청/응답 디버그 유틸을 `httpClient.debug.ts`로 분리
  - 성공/실패/예외 상황별 로그 처리 정리
  - 응답 body 파싱 및 JSON / non-JSON 예외 케이스 처리 분리
  - 민감 헤더(`Authorization`, `Cookie`, `Set-Cookie`) 마스킹 처리 추가
- `DEV_ACCESS_TOKEN` 기반 구조 유지 및 추후 `cookies()` 기반 인증 전환 맥락 보존

## 리뷰 필요

1. `httpClient`와 `httpClient.debug.ts`로 분리한 구조가 적절한지 확인 부탁드립니다.
2. 성공 로그는 `method / url / status`만 남기고, 실패 로그는 요청/응답 스냅샷을 남기도록 했는데 현재 로그 범위가 적절한지 의견 부탁드립니다.
3. 추후 `cookies()` 기반 인증으로 전환할 수 있도록 남긴 주석과 수정 포인트가 충분히 명확한지 확인 부탁드립니다.

close #40 