### PR TITLE
feat: actions fetch 함수 정의

### DIFF
--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -1,4 +1,52 @@
 'use server';
 
-// create / update / delete 작업은 여기에 Server Action으로 정의합니다.
-// 예: export async function createCompany(data: FormData) { ... }
+import { privateFetch } from '@/shared/api/httpClient';
+import type {
+  GetCompanyListParams,
+  GetCompanyListResponse,
+  GetCompanyDetailResponse,
+  CompanyDetail,
+  CreateCompanyRequest,
+  UpdateCompanyRequest,
+} from '@/features/company/types';
+
+// 기업 목록 조회 — GET /api/v1/admin/companies
+export async function getCompanyList(params?: GetCompanyListParams) {
+  const searchParams = new URLSearchParams();
+  if (params?.name) searchParams.set('name', params.name);
+  if (params?.industryType) searchParams.set('industryType', params.industryType);
+  if (params?.companyType) searchParams.set('companyType', params.companyType);
+  if (params?.page !== undefined) searchParams.set('page', String(params.page));
+  if (params?.size !== undefined) searchParams.set('size', String(params.size));
+
+  const query = searchParams.toString();
+  return privateFetch<GetCompanyListResponse>(`/api/v1/admin/companies${query ? `?${query}` : ''}`);
+}
+
+// 기업 상세 조회 — GET /api/v1/admin/companies/{id}
+export async function getCompanyDetail(companyId: number) {
+  return privateFetch<GetCompanyDetailResponse>(`/api/v1/admin/companies/${companyId}`);
+}
+
+// 기업 등록 — POST /api/v1/admin/companies
+export async function createCompany(data: CreateCompanyRequest) {
+  return privateFetch<CompanyDetail>('/api/v1/admin/companies', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+// 기업 수정 — PATCH /api/v1/admin/companies/{id}
+export async function updateCompany(companyId: number, data: UpdateCompanyRequest) {
+  return privateFetch<CompanyDetail>(`/api/v1/admin/companies/${companyId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+// 기업 삭제 — DELETE /api/v1/admin/companies/{id}
+export async function deleteCompany(companyId: number) {
+  return privateFetch<void>(`/api/v1/admin/companies/${companyId}`, {
+    method: 'DELETE',
+  });
+}


### PR DESCRIPTION
## 작업 내용

- 기업 도메인 Server Action을 실제 API 호출 기반으로 구현했습니다.
- 공통 API 래퍼 privateFetch를 사용해 인증이 필요한 요청 흐름에 맞췄습니다.
- 목록 조회 시 검색/페이징 파라미터를 URLSearchParams로 안전하게 직렬화했습니다.

## 리뷰 필요

- pnpm build 통과
- pnpm lint 에러 없음 (기존 warning 9건 존재, 본 PR 변경과 무관

close #41
