### PR TITLE
fix: 로그인 리다이랙트 로직 , 토큰 재발급

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -40,7 +40,9 @@ export default function LoginPage() {
         onSuccess: () => {
           const params = new URLSearchParams(window.location.search);
           const redirect = params.get('redirect');
-          router.push(redirect ?? '/industry');
+          const isSafePath =
+            redirect && redirect.startsWith('/') && !/[:\\/]{2}/.test(redirect);
+          router.push(isSafePath ? redirect : '/industry');
         },
         onError: (error: ApiErrorResponse) => {
           setErrorMessage(error.message || '아이디 또는 비밀번호가 올바르지 않습니다.');

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -38,7 +38,9 @@ export default function LoginPage() {
       { email, password },
       {
         onSuccess: () => {
-          router.push('/industry');
+          const params = new URLSearchParams(window.location.search);
+          const redirect = params.get('redirect');
+          router.push(redirect ?? '/industry');
         },
         onError: (error: ApiErrorResponse) => {
           setErrorMessage(error.message || '아이디 또는 비밀번호가 올바르지 않습니다.');

--- a/src/features/auth/actions.ts
+++ b/src/features/auth/actions.ts
@@ -38,7 +38,7 @@ export async function login(data: LoginRequest) {
       httpOnly: true,
       secure: isSecureCookie,
       sameSite: 'strict',
-      maxAge: 60 * 60 * 24,
+      maxAge: 60 * 60,
     });
     cookieStore.set('refreshToken', res.data.refreshToken, {
       httpOnly: true,

--- a/src/features/auth/queries.ts
+++ b/src/features/auth/queries.ts
@@ -14,7 +14,6 @@ export function useLogin() {
       }),
     onSuccess: () => {
       queryClient.clear();
-      window.location.href = '/industry';
     },
     onError: (error: ApiErrorResponse) => {
       console.error('로그인 실패:', error);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,3 @@
-import { ReissueResponse } from '@/features/auth/types';
-import { publicFetch } from '@/shared/api/httpClient';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
@@ -30,52 +28,64 @@ export async function proxy(request: NextRequest) {
 
   if (isTokenExpired && refreshToken) {
     try {
-      // 2. 토큰 재발급 API 호출
-      const refreshApiUrl = `${BASE_API_URL}/api/v1/admin/auth/reissue`;
-      const result = await publicFetch<ReissueResponse>(refreshApiUrl, {
+      // 2. 토큰 재발급 API 직접 호출 (Edge Runtime — next/headers 사용 불가)
+      const reissueRes = await fetch(`${BASE_API_URL}/api/v1/admin/auth/reissue`, {
         method: 'POST',
         headers: {
+          'Content-Type': 'application/json',
           Cookie: `refreshToken=${refreshToken}`,
         },
       });
 
-      if (result.success && result.data) {
-        const newAccessToken = result.data.accessToken;
-        const newRefreshToken = result.data.refreshToken;
+      if (reissueRes.ok) {
+        const body = await reissueRes.json();
+        const newAccessToken: string = body?.data?.accessToken;
+        const newRefreshToken: string = body?.data?.refreshToken;
 
-        // 3. 서버 컴포넌트(Server Action)가 참조할 내부 Request 헤더 조작
-        request.cookies.set('accessToken', newAccessToken);
-        request.cookies.set('refreshToken', newRefreshToken);
+        if (newAccessToken && newRefreshToken) {
+          // 3. 서버 컴포넌트(Server Action)가 참조할 내부 Request 헤더 조작
+          request.cookies.set('accessToken', newAccessToken);
+          request.cookies.set('refreshToken', newRefreshToken);
 
-        const requestHeaders = new Headers(request.headers);
-        requestHeaders.set('Cookie', request.cookies.toString());
+          const requestHeaders = new Headers(request.headers);
+          requestHeaders.set('Cookie', request.cookies.toString());
 
-        // 4. 조작된 헤더를 포함하여 요청 통과
-        const response = NextResponse.next({
-          request: { headers: requestHeaders },
-        });
+          // 4. 조작된 헤더를 포함하여 요청 통과
+          const response = NextResponse.next({
+            request: { headers: requestHeaders },
+          });
 
-        // 5. 브라우저에 저장될 Response 쿠키 세팅
-        response.cookies.set('accessToken', newAccessToken, {
-          maxAge: 60 * 60,
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: 'none',
-          path: '/',
-        });
-        response.cookies.set('refreshToken', newRefreshToken, {
-          maxAge: 60 * 60 * 24 * 14,
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: 'none',
-          path: '/',
-        });
+          // 5. 브라우저에 저장될 Response 쿠키 세팅
+          const isSecure = process.env.NODE_ENV === 'production';
+          response.cookies.set('accessToken', newAccessToken, {
+            maxAge: 60 * 60,
+            httpOnly: true,
+            secure: isSecure,
+            sameSite: 'strict',
+            path: '/',
+          });
+          response.cookies.set('refreshToken', newRefreshToken, {
+            maxAge: 60 * 60 * 24 * 14,
+            httpOnly: true,
+            secure: isSecure,
+            sameSite: 'strict',
+            path: '/',
+          });
 
-        return response;
+          return response;
+        }
       }
-    } catch (error) {
-      // 갱신 실패 시 조작 없이 통과 (이후 httpClient가 401/SESSION_EXPIRED 반환)
+    } catch {
+      // 네트워크 오류는 아래 리다이렉트 로직으로 fall-through
     }
+
+    // 재발급 실패 → refreshToken 만료로 간주, 로그인 페이지로 리다이렉트
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('redirect', pathname);
+    const redirectResponse = NextResponse.redirect(loginUrl);
+    redirectResponse.cookies.delete('accessToken');
+    redirectResponse.cookies.delete('refreshToken');
+    return redirectResponse;
   }
 
   return NextResponse.next();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,7 +14,8 @@ export async function proxy(request: NextRequest) {
   // 비로그인 상태에서 보호된 경로 접근 → /login 리다이렉트
   if (!isPublic && !refreshToken) {
     const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('redirect', pathname);
+    const { search } = request.nextUrl;
+    loginUrl.searchParams.set('redirect', pathname + search);
     return NextResponse.redirect(loginUrl);
   }
 
@@ -81,7 +82,8 @@ export async function proxy(request: NextRequest) {
 
     // 재발급 실패 → refreshToken 만료로 간주, 로그인 페이지로 리다이렉트
     const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('redirect', pathname);
+    const { search } = request.nextUrl;
+    loginUrl.searchParams.set('redirect', pathname + search);
     const redirectResponse = NextResponse.redirect(loginUrl);
     redirectResponse.cookies.delete('accessToken');
     redirectResponse.cookies.delete('refreshToken');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,6 +28,8 @@ export async function proxy(request: NextRequest) {
   const isTokenExpired = !accessToken;
 
   if (isTokenExpired && refreshToken) {
+    if (!BASE_API_URL) return NextResponse.next();
+
     try {
       // 2. 토큰 재발급 API 직접 호출 (Edge Runtime — next/headers 사용 불가)
       const reissueRes = await fetch(`${BASE_API_URL}/api/v1/admin/auth/reissue`, {

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -15,6 +15,7 @@ import {
   parseResponseBody,
 } from '@/shared/api/httpClient.debug';
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 const BASE_API_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
 // 로컬 테스트를 위한 14일 기간의 엑세스 토큰
 const ACCESS_TOKEN = process.env.DEV_ACCESS_TOKEN;
@@ -145,11 +146,52 @@ async function requestApi<T>(
   }
 }
 
+async function reissueAccessToken(): Promise<string | null> {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+  if (!refreshToken) return null;
+
+  const BASE_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
+  try {
+    const res = await fetch(`${BASE_URL}/api/v1/admin/auth/reissue`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `refreshToken=${refreshToken}`,
+      },
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    const newAccessToken: string = body?.data?.accessToken;
+    const newRefreshToken: string = body?.data?.refreshToken;
+    if (!newAccessToken || !newRefreshToken) return null;
+
+    const isSecure = process.env.NODE_ENV === 'production';
+    cookieStore.set('accessToken', newAccessToken, {
+      maxAge: 60 * 60,
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'strict',
+      path: '/',
+    });
+    cookieStore.set('refreshToken', newRefreshToken, {
+      maxAge: 60 * 60 * 24 * 14,
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'strict',
+      path: '/',
+    });
+    return newAccessToken;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * [Token O] 인증이 필요한 공통 Fetch
- * - 로그인 후 쿠키에 저장된 accessToken을 읽어 요청에 사용
- * - 401 발생 시 refreshToken으로 accessToken 재발급 후 원래 요청 재시도
- * - refreshToken도 만료된 경우 세션 만료 에러 반환
+ * - 쿠키의 accessToken으로 요청
+ * - TOKEN_EXPIRED 응답 시 refreshToken으로 재발급 후 1회 재시도
+ * - 재발급 실패 시 쿠키 삭제 후 /login 리다이렉트
  */
 export async function privateFetch<T>(
   endpoint: string,
@@ -158,11 +200,27 @@ export async function privateFetch<T>(
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
 
-  return requestApi<T>(endpoint, options, {
+  const result = await requestApi<T>(endpoint, options, {
     requireAuth: true,
     accessToken,
     sessionExpiredMessage: '세션이 만료되었습니다. 다시 로그인해 주세요.',
   });
+
+  if (!result.success && result.code === 'TOKEN_EXPIRED') {
+    const newToken = await reissueAccessToken();
+    if (!newToken) {
+      cookieStore.delete('accessToken');
+      cookieStore.delete('refreshToken');
+      redirect('/login');
+    }
+    return requestApi<T>(endpoint, options, {
+      requireAuth: true,
+      accessToken: newToken,
+      sessionExpiredMessage: '세션이 만료되었습니다. 다시 로그인해 주세요.',
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -147,12 +147,16 @@ async function requestApi<T>(
   }
 }
 
-async function reissueAccessToken(): Promise<string | null> {
+type ReissueResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; shouldLogout: boolean };
+
+async function reissueAccessToken(): Promise<ReissueResult> {
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get('refreshToken')?.value;
-  if (!refreshToken) return null;
+  if (!refreshToken) return { ok: false, shouldLogout: true };
 
-  if (!BASE_API_URL) return null;
+  if (!BASE_API_URL) return { ok: false, shouldLogout: false };
   try {
     const res = await fetch(`${BASE_API_URL}/api/v1/admin/auth/reissue`, {
       method: 'POST',
@@ -161,15 +165,21 @@ async function reissueAccessToken(): Promise<string | null> {
         Cookie: `refreshToken=${refreshToken}`,
       },
     });
-    if (!res.ok) return null;
-    const body = await res.json() as { data: ReissueResponse };
-    const newAccessToken = body?.data?.accessToken;
-    const newRefreshToken = body?.data?.refreshToken;
-    if (!newAccessToken || !newRefreshToken) return null;
+    const body = (await res.json()) as ApiResponse<ReissueResponse>;
+
+    if (!res.ok || !body.success) {
+      // 4xx(인증 오류) → 로그아웃, 5xx(서버 오류) → 원래 에러 반환
+      const shouldLogout = res.status < 500;
+      return { ok: false, shouldLogout };
+    }
+
+    const newAccessToken = body.data?.accessToken;
+    const newRefreshToken = body.data?.refreshToken;
+    if (!newAccessToken || !newRefreshToken) return { ok: false, shouldLogout: true };
 
     const isSecure = process.env.NODE_ENV === 'production';
     cookieStore.set('accessToken', newAccessToken, {
-      maxAge: 60 * 60,
+      maxAge: 60 * 60 * 24,
       httpOnly: true,
       secure: isSecure,
       sameSite: 'strict',
@@ -182,10 +192,10 @@ async function reissueAccessToken(): Promise<string | null> {
       sameSite: 'strict',
       path: '/',
     });
-    return newAccessToken;
+    return { ok: true, accessToken: newAccessToken };
   } catch (error) {
     console.error('[reissueAccessToken] 재발급 실패:', error);
-    return null;
+    return { ok: false, shouldLogout: false };
   }
 }
 
@@ -209,15 +219,18 @@ export async function privateFetch<T>(
   });
 
   if (!result.success && result.code === 'TOKEN_EXPIRED') {
-    const newToken = await reissueAccessToken();
-    if (!newToken) {
-      cookieStore.delete('accessToken');
-      cookieStore.delete('refreshToken');
-      redirect('/login');
+    const reissueResult = await reissueAccessToken();
+    if (!reissueResult.ok) {
+      if (reissueResult.shouldLogout) {
+        cookieStore.delete('accessToken');
+        cookieStore.delete('refreshToken');
+        redirect('/login');
+      }
+      return result;
     }
     return requestApi<T>(endpoint, options, {
       requireAuth: true,
-      accessToken: newToken,
+      accessToken: reissueResult.accessToken,
       sessionExpiredMessage: '세션이 만료되었습니다. 다시 로그인해 주세요.',
     });
   }

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -152,9 +152,9 @@ async function reissueAccessToken(): Promise<string | null> {
   const refreshToken = cookieStore.get('refreshToken')?.value;
   if (!refreshToken) return null;
 
-  const BASE_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
+  if (!BASE_API_URL) return null;
   try {
-    const res = await fetch(`${BASE_URL}/api/v1/admin/auth/reissue`, {
+    const res = await fetch(`${BASE_API_URL}/api/v1/admin/auth/reissue`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -16,6 +16,7 @@ import {
 } from '@/shared/api/httpClient.debug';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import type { ReissueResponse } from '@/features/auth/types';
 const BASE_API_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
 // 로컬 테스트를 위한 14일 기간의 엑세스 토큰
 const ACCESS_TOKEN = process.env.DEV_ACCESS_TOKEN;
@@ -161,9 +162,9 @@ async function reissueAccessToken(): Promise<string | null> {
       },
     });
     if (!res.ok) return null;
-    const body = await res.json();
-    const newAccessToken: string = body?.data?.accessToken;
-    const newRefreshToken: string = body?.data?.refreshToken;
+    const body = await res.json() as { data: ReissueResponse };
+    const newAccessToken = body?.data?.accessToken;
+    const newRefreshToken = body?.data?.refreshToken;
     if (!newAccessToken || !newRefreshToken) return null;
 
     const isSecure = process.env.NODE_ENV === 'production';
@@ -182,7 +183,8 @@ async function reissueAccessToken(): Promise<string | null> {
       path: '/',
     });
     return newAccessToken;
-  } catch {
+  } catch (error) {
+    console.error('[reissueAccessToken] 재발급 실패:', error);
     return null;
   }
 }


### PR DESCRIPTION
## 작업 내용

                                                                           
  - proxy.ts: Edge Runtime 호환을 위해 publicFetch 대신 fetch 직접 사용으로 변경                                                
  - proxy.ts: accessToken 쿠키 소멸 시 reissue 실패하면 쿠키 삭제 후 /login 리다이렉트 추가 (기존에는 그냥 통과)                
  - httpClient.ts: privateFetch에서 TOKEN_EXPIRED 응답 시 refreshToken으로 재발급 후 1회 재시도, 재발급 실패 시 쿠키 삭제 후    
  /login 리다이렉트                                                                                                             
  - queries.ts: useLogin onSuccess에서 window.location.href 제거 (리다이렉트 로직을 login 페이지로 일원화)                      
  - login/page.tsx: 로그인 성공 후 redirect 쿼리 파라미터가 있으면 해당 경로로 이동 
## 리뷰 필요

- proxy.ts는 accessToken 쿠키가 없을 때만 reissue를 시도하고, httpClient.ts는 accessToken이 있지만 JWT가 만료됐을 때       
  reissue를 시도 — 두 레이어가 각각 다른 케이스를 담당하는 구조


close #80
