### PR TITLE
fix:  로그인 상태관리, 빈 상태 UI, TopBar 알림 아이콘 제거     

### DIFF
--- a/src/app/(main)/recruitment/page.tsx
+++ b/src/app/(main)/recruitment/page.tsx
@@ -109,12 +109,12 @@ export default async function RecruitmentPage({
         {/* Filter Row */}
         <div className="flex items-center justify-between gap-3">
           <RecruitmentFilterToolbar tab={tab} />
-          <Button asChild>
+          {/* <Button asChild>
             <Link href="/recruitment/create" className="no-underline hover:no-underline gap-1">
               <Plus size={16} />
               공고 등록
             </Link>
-          </Button>
+          </Button> */}
         </div>
 
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -120,7 +120,7 @@ export default function LoginPage() {
 
         {/* Login Button */}
         <Button className="h-10 w-full" type="submit" form="login-form" disabled={isPending}>
-          {isPending ? '로그인 중...' : '로그인'}
+          {'로그인'}
         </Button>
 
         {/* Footer */}

--- a/src/features/auth/queries.ts
+++ b/src/features/auth/queries.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { LoginRequest, LoginResponse } from '@/features/auth/types';
 import { login, logout } from '@/features/auth/actions';
 import type { ApiErrorResponse, ApiSuccessResponse } from '@/shared/types/api';
+import { useAuthStore } from '@/shared/store/authStore';
 
 export function useLogin() {
   const queryClient = useQueryClient();
+  const setUser = useAuthStore((state) => state.setUser);
 
   return useMutation<ApiSuccessResponse<LoginResponse>, ApiErrorResponse, LoginRequest>({
     mutationFn: (data: LoginRequest) =>
@@ -12,10 +14,14 @@ export function useLogin() {
         if (!result.success) return Promise.reject(result);
         return result;
       }),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      if (result.data.user) {
+        setUser(result.data.user);
+      }
       queryClient.clear();
       window.location.href = '/industry';
     },
+
     onError: (error: ApiErrorResponse) => {
       console.error('로그인 실패:', error);
     },
@@ -25,10 +31,12 @@ export function useLogin() {
 // 로그아웃
 export function useLogout() {
   const queryClient = useQueryClient();
+  const clearUser = useAuthStore((state) => state.clearUser);
 
   return useMutation({
     mutationFn: () => logout(),
     onSuccess: () => {
+      clearUser();
       queryClient.clear();
       window.location.href = '/login';
     },

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -14,6 +14,7 @@ export type LoginResponse = {
   grantType: string;
   accessToken: string;
   refreshToken: string;
+  user?: User;
 };
 
 // 로그인 요청

--- a/src/features/company/components/section/CompanyTable.tsx
+++ b/src/features/company/components/section/CompanyTable.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useCompanyList } from '@/features/company/queries';
+import EmptyState from '@/shared/components/ui/EmptyState';
 import CompanyRow from '@/features/company/components/ui/CompanyRow';
 import type { GetCompanyListParams } from '@/features/company/types';
 
@@ -56,32 +57,37 @@ export default function CompanyTable({ params }: CompanyTableProps) {
         <div className="min-w-274">
           {headerRow}
 
-          {companies.map((company, i) => (
-            <CompanyRow
-              key={company.companyId}
-              no={page * 10 + i + 1}
-              company={company}
-              industryName={company.industryName}
-              last={i === companies.length - 1}
-            />
-          ))}
+          {companies.length > 0 ? (
+            companies.map((company, i) => (
+              <CompanyRow
+                key={company.companyId}
+                no={page * 10 + i + 1}
+                company={company}
+                industryName={company.industryName}
+                last={i === companies.length - 1}
+              />
+            ))
+          ) : (
+            <EmptyState message="등록된 기업이 없습니다." />
+          )}
         </div>
       </div>
 
-      {/* Pagination Footer */}
-      <div className="h-13 border-t border-ds-grey-200 flex items-center justify-center gap-1 px-4">
-        {Array.from({ length: pageInfo.totalPages ?? 1 }).map((_, i) => (
-          <button
-            key={i}
-            onClick={() => handlePageChange(i)}
-            className={`w-8 h-8 flex items-center justify-center rounded-md text-sm font-medium cursor-pointer ${
-              i === page ? 'bg-ds-grey-900 text-white' : 'text-ds-grey-600 hover:bg-ds-grey-100'
-            }`}
-          >
-            {i + 1}
-          </button>
-        ))}
-      </div>
+      {companies.length > 0 && (
+        <div className="h-13 border-t border-ds-grey-200 flex items-center justify-center gap-1 px-4">
+          {Array.from({ length: pageInfo.totalPages ?? 1 }).map((_, i) => (
+            <button
+              key={i}
+              onClick={() => handlePageChange(i)}
+              className={`w-8 h-8 flex items-center justify-center rounded-md text-sm font-medium cursor-pointer ${
+                i === page ? 'bg-ds-grey-900 text-white' : 'text-ds-grey-600 hover:bg-ds-grey-100'
+              }`}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/industry/components/section/IndustryList.tsx
+++ b/src/features/industry/components/section/IndustryList.tsx
@@ -2,6 +2,7 @@
 
 import { useIndustryCategoryList } from '@/features/industry/queries';
 import IndustryCard from '@/features/industry/components/ui/IndustryCard';
+import EmptyState from '@/shared/components/ui/EmptyState';
 
 export default function IndustryList() {
   const { data: categories, isLoading, isError, error } = useIndustryCategoryList();
@@ -22,6 +23,10 @@ export default function IndustryList() {
         산업 카테고리를 불러오지 못했습니다. {error?.message}
       </p>
     );
+  }
+
+  if (categories.length === 0) {
+    return <EmptyState message="등록된 산업군이 없습니다." className="py-16" />;
   }
 
   return (

--- a/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useRecruitmentAnalysisList, useDeleteRecruitment } from '@/features/recruitment/queries';
+import EmptyState from '@/shared/components/ui/EmptyState';
 import { toast } from 'sonner';
 import type { ApiErrorResponse } from '@/shared/types/api';
 import type { RecruitmentAnalysisStatus, RecruitmentSummary } from '@/features/recruitment/types';
@@ -68,24 +69,22 @@ export default function RecruitmentAnalysisList() {
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
           </div>
 
-          {rows.length > 0 && rows.map((item, i) => (
-            <RecruitmentAnalysisRow
-              key={item.postId}
-              no={page * 10 + i + 1}
-              item={item}
-              last={i === rows.length - 1}
-              isDeleting={isDeleting}
-              onDelete={handleDelete}
-            />
-          ))}
+          {rows.length > 0 ? (
+            rows.map((item, i) => (
+              <RecruitmentAnalysisRow
+                key={item.postId}
+                no={page * 10 + i + 1}
+                item={item}
+                last={i === rows.length - 1}
+                isDeleting={isDeleting}
+                onDelete={handleDelete}
+              />
+            ))
+          ) : (
+            <EmptyState message="진행 중인 분석 공고가 없습니다." />
+          )}
         </div>
       </div>
-
-      {rows.length === 0 && (
-        <div className="flex items-center justify-center h-32 text-sm text-ds-grey-400">
-          진행 중인 분석 공고가 없습니다.
-        </div>
-      )}
 
       {/* Pagination Footer */}
       {rows.length > 0 && (

--- a/src/features/recruitment/components/section/RecruitmentList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentList.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useRecruitmentList, useDeleteRecruitment } from '@/features/recruitment/queries';
+import EmptyState from '@/shared/components/ui/EmptyState';
 import { toast } from 'sonner';
 import type { ApiErrorResponse } from '@/shared/types/api';
 import RecruitmentRow from '@/features/recruitment/components/ui/RecruitmentRow';
@@ -51,33 +52,38 @@ export default function RecruitmentList() {
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
           </div>
 
-          {rows.map((item, i) => (
-            <RecruitmentRow
-              key={item.postId}
-              no={page * 10 + i + 1}
-              item={item}
-              last={i === rows.length - 1}
-              isDeleting={isDeleting}
-              onDelete={handleDelete}
-            />
-          ))}
+          {rows.length > 0 ? (
+            rows.map((item, i) => (
+              <RecruitmentRow
+                key={item.postId}
+                no={page * 10 + i + 1}
+                item={item}
+                last={i === rows.length - 1}
+                isDeleting={isDeleting}
+                onDelete={handleDelete}
+              />
+            ))
+          ) : (
+            <EmptyState message="등록된 공고가 없습니다." />
+          )}
         </div>
       </div>
 
-      {/* Pagination Footer */}
-      <div className="h-13 border-t border-ds-grey-200 flex items-center justify-center gap-1 px-4">
-        {Array.from({ length: pageInfo?.totalPages ?? 1 }).map((_, i) => (
-          <button
-            key={i}
-            onClick={() => handlePageChange(i)}
-            className={`w-8 h-8 flex items-center justify-center rounded-md text-sm font-medium cursor-pointer ${
-              i === page ? 'bg-ds-grey-900 text-white' : 'text-ds-grey-600 hover:bg-ds-grey-100'
-            }`}
-          >
-            {i + 1}
-          </button>
-        ))}
-      </div>
+      {rows.length > 0 && (
+        <div className="h-13 border-t border-ds-grey-200 flex items-center justify-center gap-1 px-4">
+          {Array.from({ length: pageInfo?.totalPages ?? 1 }).map((_, i) => (
+            <button
+              key={i}
+              onClick={() => handlePageChange(i)}
+              className={`w-8 h-8 flex items-center justify-center rounded-md text-sm font-medium cursor-pointer ${
+                i === page ? 'bg-ds-grey-900 text-white' : 'text-ds-grey-600 hover:bg-ds-grey-100'
+              }`}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/recruitment/components/section/RecruitmentRequestList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentRequestList.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useRecruitmentSubmissionList } from '@/features/recruitment/queries';
+import EmptyState from '@/shared/components/ui/EmptyState';
 import type { RecruitmentRequestStatus } from '@/features/recruitment/types';
 import RecruitmentRequestRow from '@/features/recruitment/components/ui/RecruitmentRequestRow';
 
@@ -39,30 +40,40 @@ export default function RecruitmentRequestList() {
         <div className="min-w-240">
           {/* Header Row */}
           <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200">
-            <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">No.</div>
-            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">플랫폼</div>
-            <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 URL</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청 상태</div>
-            <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청일</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
+            <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              No.
+            </div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              플랫폼
+            </div>
+            <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
+              공고 URL
+            </div>
+            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              요청 상태
+            </div>
+            <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              요청일
+            </div>
+            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              액션
+            </div>
           </div>
 
-          {items.length > 0 && items.map((item, i) => (
-            <RecruitmentRequestRow
-              key={item.submissionId}
-              no={page * 10 + i + 1}
-              item={item}
-              last={i === items.length - 1}
-            />
-          ))}
+          {items.length > 0 ? (
+            items.map((item, i) => (
+              <RecruitmentRequestRow
+                key={item.submissionId}
+                no={page * 10 + i + 1}
+                item={item}
+                last={i === items.length - 1}
+              />
+            ))
+          ) : (
+            <EmptyState message="요청된 공고가 없습니다." />
+          )}
         </div>
       </div>
-
-      {items.length === 0 && (
-        <div className="flex items-center justify-center h-32 text-sm text-ds-grey-400">
-          요청된 공고가 없습니다.
-        </div>
-      )}
 
       {/* Pagination Footer */}
       {items.length > 0 && (

--- a/src/shared/components/layout/Sidebar.tsx
+++ b/src/shared/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { Separator } from '@/shared/components/ui/separator';
 import { Sheet, SheetContent, SheetTitle } from '@/shared/components/ui/sheet';
 import { cn } from '@/shared/lib/cn';
 import { useLogout } from '@/features/auth/queries';
+import { useAuthStore } from '@/shared/store/authStore';
 
 const navItems = [
   //{ label: '대시보드', icon: LayoutDashboard, href: '/' }, TODO: 대시보드 페이지 개발 후 활성화
@@ -21,6 +22,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { mutate: handleLogout, isPending } = useLogout();
   const [isOpen, setIsOpen] = useState(false);
+  const user = useAuthStore((state) => state.user);
 
   const sidebarContent = (
     <aside className="w-64 shrink-0 bg-white flex flex-col p-2 gap-4 h-full">
@@ -33,7 +35,7 @@ export default function Sidebar() {
       {/* Nav */}
       <div className="flex-1 flex flex-col gap-0.5">
         <div className="px-2 py-1">
-          <span className="text-xs text-ds-grey-500">관리자</span>
+          <span className="text-xs text-ds-grey-500">{user?.name}</span>
         </div>
 
         {navItems.map((item) => {
@@ -70,8 +72,8 @@ export default function Sidebar() {
               <span className="text-white text-xs font-semibold">관</span>
             </div>
             <div className="flex flex-col min-w-0">
-              <span className="text-xs font-medium text-ds-grey-900 truncate">관리자</span>
-              <span className="text-[11px] text-ds-grey-500 truncate">admin@gonggomoon.com</span>
+              <span className="text-xs font-medium text-ds-grey-900 truncate">{user?.name}</span>
+              <span className="text-[11px] text-ds-grey-500 truncate">{user?.email}</span>
             </div>
           </div>
           <Button
@@ -105,9 +107,7 @@ export default function Sidebar() {
       </Button>
 
       {/* lg 이상: static sidebar */}
-      <div className="hidden lg:flex h-full border-r border-ds-grey-200">
-        {sidebarContent}
-      </div>
+      <div className="hidden lg:flex h-full border-r border-ds-grey-200">{sidebarContent}</div>
 
       {/* lg 미만: Sheet 기반 모바일 drawer */}
       <Sheet open={isOpen} onOpenChange={setIsOpen}>

--- a/src/shared/components/layout/TopBar.tsx
+++ b/src/shared/components/layout/TopBar.tsx
@@ -1,5 +1,3 @@
-import { Bell } from 'lucide-react';
-import { Button } from '@/shared/components/ui/button';
 import { cn } from '@/shared/lib/cn';
 
 interface TopBarProps {
@@ -10,15 +8,15 @@ interface TopBarProps {
 
 export default function TopBar({ title, breadcrumb, className }: TopBarProps) {
   return (
-    <header className={cn('h-14 shrink-0 bg-white border-b border-ds-grey-200 flex items-center justify-between pl-14 pr-6 lg:px-6', className)}>
+    <header
+      className={cn(
+        'h-14 shrink-0 bg-white border-b border-ds-grey-200 flex items-center justify-between pl-14 pr-6 lg:px-6',
+        className,
+      )}
+    >
       <div className="flex flex-col gap-0.5">
         <span className="text-base font-semibold text-ds-grey-900">{title}</span>
         <span className="text-xs text-ds-grey-500">{breadcrumb}</span>
-      </div>
-      <div className="flex items-center gap-3">
-        <Button variant="ghost" size="icon-sm" className="text-ds-grey-600" aria-label="알림">
-          <Bell size={20} />
-        </Button>
       </div>
     </header>
   );

--- a/src/shared/components/ui/EmptyState.tsx
+++ b/src/shared/components/ui/EmptyState.tsx
@@ -1,0 +1,16 @@
+import { Inbox } from 'lucide-react';
+import { cn } from '@/shared/lib/cn';
+
+interface EmptyStateProps {
+  message: string;
+  className?: string;
+}
+
+export default function EmptyState({ message, className }: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center gap-2 py-12 text-ds-grey-400', className)}>
+      <Inbox size={32} strokeWidth={1.5} />
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import type { User } from '@/features/auth/types';
+
+type AuthState = {
+  user: User | null;
+  setUser: (user: User) => void;
+  clearUser: () => void;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+}));


### PR DESCRIPTION
## 작업 내용

- 로그인 응답의 user 정보를 Zustand store(useAuthStore)에 저장,          
  사이드바에 이름/이메일 표시                                              
  - 산업군·기업·공고(공개/요청/분석) 목록 빈 상태 UI 추가 (EmptyState 공통 
  컴포넌트)                                                                
  - 빈 상태일 때 페이지네이션 숨김 처리                                    
  - TopBar 알림(Bell) 아이콘 제거                                          
  - 로그아웃 시 store 초기화            

## 리뷰 필요                                                    
                                                                           
  - 백엔드 로그인 응답에 아직 `user` 필드가 없어 `LoginResponse.user`는    
  optional 처리                                                            
    → 백엔드 반영 시 자동으로 사이드바에 유저 정보 표시됨 

close #89 
