### PR TITLE
style: 테이블 컬럼 너비 개선 - 넓은 화면에서 빈 공간 제거 

### DIFF
--- a/src/features/company/components/section/CompanyTable.tsx
+++ b/src/features/company/components/section/CompanyTable.tsx
@@ -94,6 +94,7 @@ const headerRow = (
     <div className="flex-1 min-w-52 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
       기업명
     </div>
+
     <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       사업 분야
     </div>
@@ -106,7 +107,7 @@ const headerRow = (
     <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       설립연도
     </div>
-    <div className="flex-1 min-w-72 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
+    <div className="w-72 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       액션
     </div>
   </div>

--- a/src/features/company/components/section/CompanyTable.tsx
+++ b/src/features/company/components/section/CompanyTable.tsx
@@ -91,10 +91,10 @@ const headerRow = (
     <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       No.
     </div>
-    <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+    <div className="flex-1 min-w-52 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
       기업명
     </div>
-    <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+    <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       사업 분야
     </div>
     <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
@@ -106,7 +106,7 @@ const headerRow = (
     <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
       설립연도
     </div>
-    <div className="w-72 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+    <div className="flex-1 min-w-72 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
       액션
     </div>
   </div>

--- a/src/features/company/components/ui/CompanyRow.tsx
+++ b/src/features/company/components/ui/CompanyRow.tsx
@@ -43,8 +43,12 @@ export default function CompanyRow({ no, company, industryName, last = false }: 
     <>
       <div className={`flex items-center h-14 ${!last ? 'border-b border-ds-grey-200' : ''}`}>
         <div className="w-14 px-4 text-[13px] text-ds-grey-600 shrink-0">{no}</div>
-        <div className="w-44 px-4 text-sm font-medium text-ds-grey-900 shrink-0 whitespace-nowrap truncate">{company.companyName}</div>
-        <div className="w-36 px-4 text-sm text-ds-grey-900 shrink-0 whitespace-nowrap truncate">{industryName ?? '-'}</div>
+        <div className="flex-1 min-w-52 px-4 text-sm font-medium text-ds-grey-900 truncate">
+          {company.companyName}
+        </div>
+        <div className="w-44 px-4 text-sm text-ds-grey-900 shrink-0 truncate">
+          {industryName ?? '-'}
+        </div>
         <div className="w-44 px-4 shrink-0">
           <span
             className={`inline-flex px-2 py-1 rounded-md text-xs font-medium whitespace-nowrap ${COMPANY_TYPE_OPTIONS.find((option) => option.value === company.companyType)?.style}`}
@@ -55,8 +59,10 @@ export default function CompanyRow({ no, company, industryName, last = false }: 
         <div className="w-32 px-4 text-sm text-ds-grey-700 shrink-0 whitespace-nowrap">
           {company.employeeCount != null ? `${company.employeeCount.toLocaleString()}명` : '-'}
         </div>
-        <div className="w-32 px-4 text-sm text-ds-grey-700 shrink-0 whitespace-nowrap">{company.foundedYear ?? '-'}</div>
-        <div className="w-72 px-4 flex items-center gap-2 shrink-0">
+        <div className="w-32 px-4 text-sm text-ds-grey-700 shrink-0 whitespace-nowrap">
+          {company.foundedYear ? `${company.foundedYear}년` : '-'}
+        </div>
+        <div className="flex-1 min-w-72 px-4 flex items-center gap-2">
           <Link
             href={`https://gonggomoon.com/company/${company.companyId}`}
             target="_blank"

--- a/src/features/company/components/ui/CompanyRow.tsx
+++ b/src/features/company/components/ui/CompanyRow.tsx
@@ -62,7 +62,7 @@ export default function CompanyRow({ no, company, industryName, last = false }: 
         <div className="w-32 px-4 text-sm text-ds-grey-700 shrink-0 whitespace-nowrap">
           {company.foundedYear ? `${company.foundedYear}년` : '-'}
         </div>
-        <div className="flex-1 min-w-72 px-4 flex items-center gap-2">
+        <div className="w-72 px-4 flex items-center gap-2 shrink-0">
           <Link
             href={`https://gonggomoon.com/company/${company.companyId}`}
             target="_blank"

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -62,10 +62,10 @@ export default function IndustryAnalysisTable({
           <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">
             분석 연도
           </div>
-          <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">등록일</div>
+          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">등록일</div>
           <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">수정일</div>
           <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">상태</div>
-          <div className="flex-1 min-w-72 px-4 text-[13px] font-medium text-ds-grey-600">액션</div>
+          <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">액션</div>
         </div>
 
         {analysis.map((item, i) => (

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -8,6 +8,7 @@ import type { IndustryAnalysisListItem } from '@/features/industry/types';
 import { ApiErrorResponse } from '@/shared/types/api';
 import { toast } from 'sonner';
 import AnalysisRow from '@/features/industry/components/ui/AnalysisRow';
+import EmptyState from '@/shared/components/ui/EmptyState';
 
 interface IndustryAnalysisTableProps {
   industryId: number;
@@ -62,24 +63,32 @@ export default function IndustryAnalysisTable({
           <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">
             분석 연도
           </div>
-          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">등록일</div>
-          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">수정일</div>
+          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">
+            등록일
+          </div>
+          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">
+            수정일
+          </div>
           <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">상태</div>
           <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">액션</div>
         </div>
 
-        {analysis.map((item, i) => (
-          <AnalysisRow
-            key={item.reportId}
-            item={item}
-            industryId={industryId}
-            last={i === analysis.length - 1}
-            isPublishing={isPublishing}
-            isDeleting={isDeleting}
-            onPublish={handlePublish}
-            onDelete={handleDelete}
-          />
-        ))}
+        {analysis.length > 0 ? (
+          analysis.map((item, i) => (
+            <AnalysisRow
+              key={item.reportId}
+              item={item}
+              industryId={industryId}
+              last={i === analysis.length - 1}
+              isPublishing={isPublishing}
+              isDeleting={isDeleting}
+              onPublish={handlePublish}
+              onDelete={handleDelete}
+            />
+          ))
+        ) : (
+          <EmptyState message="등록된 분석이 없습니다." />
+        )}
       </div>
     </div>
   );

--- a/src/features/industry/components/section/IndustryAnalysisTable.tsx
+++ b/src/features/industry/components/section/IndustryAnalysisTable.tsx
@@ -45,7 +45,7 @@ export default function IndustryAnalysisTable({
   };
 
   return (
-    <div className="bg-white rounded-lg border border-ds-grey-200 px-6 py-5 flex flex-col gap-4 overflow-hidden">
+    <div className="bg-white rounded-lg border border-ds-grey-200 px-6 py-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <span className="text-[15px] font-semibold text-ds-grey-900">분석 버전 관리</span>
         <Button asChild className="h-10 gap-1.5">
@@ -58,14 +58,14 @@ export default function IndustryAnalysisTable({
       <div className="h-px bg-ds-grey-200" />
 
       <div className="rounded-md border border-ds-grey-200 overflow-x-auto">
-        <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200 min-w-[48rem]">
-          <div className="w-24 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">
+        <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200 min-w-max w-full">
+          <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">
             분석 연도
           </div>
-          <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">등록일</div>
-          <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">수정일</div>
-          <div className="w-24 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">상태</div>
-          <div className="w-72 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">액션</div>
+          <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">등록일</div>
+          <div className="flex-1 min-w-44 px-4 text-[13px] font-medium text-ds-grey-600">수정일</div>
+          <div className="w-36 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0">상태</div>
+          <div className="flex-1 min-w-72 px-4 text-[13px] font-medium text-ds-grey-600">액션</div>
         </div>
 
         {analysis.map((item, i) => (

--- a/src/features/industry/components/ui/AnalysisRow.tsx
+++ b/src/features/industry/components/ui/AnalysisRow.tsx
@@ -35,17 +35,17 @@ export default function AnalysisRow({
 
   return (
     <>
-      <div className={`flex items-center h-14 min-w-[48rem] ${!last ? 'border-b border-ds-grey-200' : ''}`}>
-        <div className="w-24 px-4 text-sm font-semibold text-ds-grey-900 shrink-0">
+      <div className={`flex items-center h-14 min-w-max w-full ${!last ? 'border-b border-ds-grey-200' : ''}`}>
+        <div className="w-36 px-4 text-sm font-semibold text-ds-grey-900 shrink-0">
           {item.reportYear}
         </div>
-        <div className="w-36 px-4 text-[13px] text-ds-grey-700 shrink-0">
+        <div className="w-44 px-4 text-[13px] text-ds-grey-700 shrink-0">
           {formatDate(item.createdAt)}
         </div>
-        <div className="w-36 px-4 text-[13px] text-ds-grey-700 shrink-0">
+        <div className="flex-1 min-w-44 px-4 text-[13px] text-ds-grey-700">
           {formatDate(item.updatedAt)}
         </div>
-        <div className="w-24 px-4 shrink-0">
+        <div className="w-36 px-4 shrink-0">
           <span
             className={`inline-flex px-2 py-0.5 rounded-md text-xs font-medium ${
               isPublished
@@ -56,7 +56,7 @@ export default function AnalysisRow({
             {statusLabel}
           </span>
         </div>
-        <div className="w-72 px-4 flex items-center gap-2 shrink-0">
+        <div className="flex-1 min-w-72 px-4 flex items-center gap-2">
           <Link
             href={`/industry/${industryId}/analysis/${item.reportId}`}
             className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-ds-grey-200 bg-white px-3 text-sm font-medium text-ds-grey-600 no-underline visited:text-ds-grey-600 hover:bg-ds-grey-50 whitespace-nowrap shrink-0"

--- a/src/features/industry/components/ui/AnalysisRow.tsx
+++ b/src/features/industry/components/ui/AnalysisRow.tsx
@@ -39,7 +39,7 @@ export default function AnalysisRow({
         <div className="w-36 px-4 text-sm font-semibold text-ds-grey-900 shrink-0">
           {item.reportYear}
         </div>
-        <div className="w-44 px-4 text-[13px] text-ds-grey-700 shrink-0">
+        <div className="flex-1 min-w-44 px-4 text-[13px] text-ds-grey-700">
           {formatDate(item.createdAt)}
         </div>
         <div className="flex-1 min-w-44 px-4 text-[13px] text-ds-grey-700">
@@ -56,7 +56,7 @@ export default function AnalysisRow({
             {statusLabel}
           </span>
         </div>
-        <div className="flex-1 min-w-72 px-4 flex items-center gap-2">
+        <div className="w-56 px-4 flex items-center gap-2 shrink-0">
           <Link
             href={`/industry/${industryId}/analysis/${item.reportId}`}
             className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-ds-grey-200 bg-white px-3 text-sm font-medium text-ds-grey-600 no-underline visited:text-ds-grey-600 hover:bg-ds-grey-50 whitespace-nowrap shrink-0"

--- a/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
@@ -65,7 +65,7 @@ export default function RecruitmentAnalysisList() {
             <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청 상태</div>
             <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">시작일</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
           </div>
 
           {rows.length > 0 && rows.map((item, i) => (

--- a/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentAnalysisList.tsx
@@ -65,7 +65,7 @@ export default function RecruitmentAnalysisList() {
             <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청 상태</div>
             <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">시작일</div>
-            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
           </div>
 
           {rows.length > 0 && rows.map((item, i) => (

--- a/src/features/recruitment/components/section/RecruitmentList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentList.tsx
@@ -49,12 +49,24 @@ export default function RecruitmentList({ status }: RecruitmentListProps) {
         <div className="min-w-240">
           {/* Header Row */}
           <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200">
-            <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">No.</div>
-            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">기업명</div>
-            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">채용 기간</div>
-            <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">상태</div>
-            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
+            <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              No.
+            </div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              기업명
+            </div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">
+              공고 제목
+            </div>
+            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              채용 기간
+            </div>
+            <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              상태
+            </div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">
+              액션
+            </div>
           </div>
 
           {rows.length > 0 ? (

--- a/src/features/recruitment/components/section/RecruitmentList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentList.tsx
@@ -51,9 +51,9 @@ export default function RecruitmentList({ status }: RecruitmentListProps) {
             <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">No.</div>
             <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">기업명</div>
             <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
-            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">채용 기간</div>
+            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">채용 기간</div>
             <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">상태</div>
-            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
           </div>
 
           {rows.map((item, i) => (

--- a/src/features/recruitment/components/section/RecruitmentList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentList.tsx
@@ -50,10 +50,10 @@ export default function RecruitmentList({ status }: RecruitmentListProps) {
           <div className="flex items-center h-11 bg-ds-grey-50 border-b border-ds-grey-200">
             <div className="w-14 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">No.</div>
             <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">기업명</div>
-            <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">채용 기간</div>
-            <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">상태</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 제목</div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">채용 기간</div>
+            <div className="w-32 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">상태</div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
           </div>
 
           {rows.map((item, i) => (

--- a/src/features/recruitment/components/section/RecruitmentRequestList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentRequestList.tsx
@@ -44,7 +44,7 @@ export default function RecruitmentRequestList() {
             <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 URL</div>
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청 상태</div>
             <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청일</div>
-            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
+            <div className="w-44 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
           </div>
 
           {items.length > 0 && items.map((item, i) => (

--- a/src/features/recruitment/components/section/RecruitmentRequestList.tsx
+++ b/src/features/recruitment/components/section/RecruitmentRequestList.tsx
@@ -44,7 +44,7 @@ export default function RecruitmentRequestList() {
             <div className="flex-1 min-w-50 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">공고 URL</div>
             <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청 상태</div>
             <div className="w-28 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">요청일</div>
-            <div className="w-56 px-4 text-[13px] font-medium text-ds-grey-600 shrink-0 whitespace-nowrap">액션</div>
+            <div className="flex-1 min-w-56 px-4 text-[13px] font-medium text-ds-grey-600 whitespace-nowrap">액션</div>
           </div>
 
           {items.length > 0 && items.map((item, i) => (

--- a/src/features/recruitment/components/ui/RecruitmentAnalysisRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentAnalysisRow.tsx
@@ -57,7 +57,7 @@ export default function RecruitmentAnalysisRow({
         <div className="w-28 px-4 text-[13px] text-ds-grey-700 shrink-0">
           {formatDate(item.startDate)}
         </div>
-        <div className="w-56 px-4 flex items-center gap-2 shrink-0">
+        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
           {isAnalyzing ? (
             <Button disabled size="sm" variant="outline" className="gap-1.5 text-ds-grey-500">
               <FileSearch size={13} />

--- a/src/features/recruitment/components/ui/RecruitmentAnalysisRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentAnalysisRow.tsx
@@ -57,7 +57,7 @@ export default function RecruitmentAnalysisRow({
         <div className="w-28 px-4 text-[13px] text-ds-grey-700 shrink-0">
           {formatDate(item.startDate)}
         </div>
-        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
+        <div className="w-44 px-4 flex items-center gap-2 shrink-0">
           {isAnalyzing ? (
             <Button disabled size="sm" variant="outline" className="gap-1.5 text-ds-grey-500">
               <FileSearch size={13} />

--- a/src/features/recruitment/components/ui/RecruitmentRequestRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentRequestRow.tsx
@@ -62,7 +62,7 @@ export default function RecruitmentRequestRow({
         <div className="w-28 px-4 text-[13px] text-ds-grey-700 shrink-0">
           {formatDate(item.createdAt)}
         </div>
-        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
+        <div className="w-44 px-4 flex items-center gap-2 shrink-0">
           {isPending ? (
             <Button
               size="sm"

--- a/src/features/recruitment/components/ui/RecruitmentRequestRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentRequestRow.tsx
@@ -62,7 +62,7 @@ export default function RecruitmentRequestRow({
         <div className="w-28 px-4 text-[13px] text-ds-grey-700 shrink-0">
           {formatDate(item.createdAt)}
         </div>
-        <div className="w-56 px-4 flex items-center gap-2 shrink-0">
+        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
           {isPending ? (
             <Button
               size="sm"

--- a/src/features/recruitment/components/ui/RecruitmentRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentRow.tsx
@@ -46,20 +46,20 @@ export default function RecruitmentRow({
         <div className="w-44 px-4 text-sm text-ds-grey-900 shrink-0 truncate">
           {item.companyName}
         </div>
-        <div className="flex-1 min-w-0 px-4 text-sm text-ds-grey-900 truncate">
+        <div className="flex-1 min-w-56 px-4 text-sm text-ds-grey-900 truncate">
           {item.postTitle}
         </div>
-        <div className="w-56 px-4 text-[13px] text-ds-grey-700 shrink-0 whitespace-nowrap">
+        <div className="flex-1 min-w-56 px-4 text-[13px] text-ds-grey-700 whitespace-nowrap">
           {item.startDate?.slice(0, 10) ?? '-'} ~ {item.dueDate?.slice(0, 10) ?? '상시'}
         </div>
-        <div className="w-28 px-4 shrink-0">
+        <div className="w-32 px-4 shrink-0">
           <span
             className={`inline-flex px-2 py-0.5 rounded-md text-xs font-medium ${publicStatusBadge}`}
           >
             {publicStatusLabel}
           </span>
         </div>
-        <div className="w-56 px-4 flex items-center gap-2 shrink-0">
+        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
           <Link
             href={`https://gonggomoon.com/recruitment/${item.postId}`}
             target="_blank"

--- a/src/features/recruitment/components/ui/RecruitmentRow.tsx
+++ b/src/features/recruitment/components/ui/RecruitmentRow.tsx
@@ -49,7 +49,7 @@ export default function RecruitmentRow({
         <div className="flex-1 min-w-56 px-4 text-sm text-ds-grey-900 truncate">
           {item.postTitle}
         </div>
-        <div className="flex-1 min-w-56 px-4 text-[13px] text-ds-grey-700 whitespace-nowrap">
+        <div className="w-56 px-4 text-[13px] text-ds-grey-700 shrink-0 whitespace-nowrap">
           {item.startDate?.slice(0, 10) ?? '-'} ~ {item.dueDate?.slice(0, 10) ?? '상시'}
         </div>
         <div className="w-32 px-4 shrink-0">
@@ -59,7 +59,7 @@ export default function RecruitmentRow({
             {publicStatusLabel}
           </span>
         </div>
-        <div className="flex-1 min-w-56 px-4 flex items-center gap-2">
+        <div className="w-44 px-4 flex items-center gap-2 shrink-0">
           <Link
             href={`https://gonggomoon.com/recruitment/${item.postId}`}
             target="_blank"


### PR DESCRIPTION
## 작업 내용   

  - 산업 분석 / 기업 / 공고(공개·요청·분석) 테이블 전체 컬럼 너비 개선                 
  - 고정 너비 컬럼만 있던 구조에서 주요 컬럼에 `flex-1` 적용
    → 화면이 넓어질 때 오른쪽에 불필요한 빈 공간이 생기지 않음                         
  - 각 테이블별 변동 컬럼:                                                             
    - 산업 분석: 수정일 · 액션                                                         
    - 기업: 기업명 · 액션                                                              
    - 공개 공고: 공고 제목 · 채용 기간 · 액션                                          
    - 요청 공고 / 공고 분석: 액션                                                      
  - 고정 컬럼들의 기본 너비도 기존보다 넓게 조정                                       
  - `IndustryAnalysisTable` 카드의 `overflow-hidden` 제거 → 내부 스크롤 정상화         
  - `CompanyRow` 설립연도 표기 버그 수정 (`foundedYear ?? '-'` → 조건부 표현식) 

## 리뷰 필요

 - 각 테이블에서 변동 너비로 선택한 컬럼이 적절한지 확인           
  - `IndustryAnalysisTable`은 카드 내부 padding 구조상 `min-w-max w-full` 방식을 사용했는데, 더 나은 방법이 있다면 의견 주세요.  

close #90 
